### PR TITLE
chore(DIST-144): Update Travis npm release config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,9 @@ jobs:
         - yarn test:visual:firefox
         - kill $EMBED_PID
     - stage: "Release"
-      name: "Deploy"
+      name: "Deploy Preview to AWS"
       # Deploy to preview preview URL for testing purposes. Only deploy pull requests to 'release' branch.
-      if: branch = release
+      if: branch = release AND type = pull_request
       script:
         - yarn build
         - pip install --user awscli
@@ -95,11 +95,8 @@ jobs:
       script:
         - yarn semantic-release
     - name: "Release to AWS"
-      # Deploy to AWS production is done by copying already deployed sources via "Test and Publish" job.
-      # This allows us to rollback quickly (no building, just copy existing file).
-      git:
-        clone: false
       if: branch = release AND type = push
       script:
+        - yarn build
         - pip install --user awscli
-        - aws s3 cp s3://$AWS_ASSETS_BUCKET/$TRAVIS_COMMIT s3://$AWS_ASSETS_BUCKET/ --recursive --acl public-read
+        - aws s3 cp ./dist s3://$AWS_ASSETS_BUCKET --recursive --acl public-read

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:functional:firefox": "yarn cypress run --browser firefox",
     "test:functional:chrome": "yarn cypress run --browser chrome",
     "prepublish": "yarn run lib",
-    "semantic-release": "semantic-release",
+    "semantic-release": "semantic-release --branch release",
     "travis-deploy-once": "travis-deploy-once --pro",
     "copy": "yarn run copy:assets && yarn run copy:helpcenter && yarn run copy:demo",
     "copy:assets": "copyfiles -f assets/* dist",
@@ -142,8 +142,5 @@
       "pre-commit": "yarn run lint",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
-  },
-  "release": {
-    "branches": ["release"]
   }
 }


### PR DESCRIPTION
Docs for semantic release say it should be configurable via `release` prop in package.json but it does not work. Passing the argument to the command directly seems to work.