### PR TITLE
fix(DIST-137): Iframe reference

### DIFF
--- a/src/core/views/components/iframe.js
+++ b/src/core/views/components/iframe.js
@@ -23,6 +23,9 @@ class Iframe extends Component {
 
   // Fixes scroll not responding in renderer v1
   handleLoad () {
+    if (!this.iframeRef) {
+      return
+    }
     this.iframeRef.style.height = `${this.iframeRef.offsetHeight + 1}px`
     setTimeout(() => {
       this.iframeRef.style.height = ''


### PR DESCRIPTION
This should fix the error in functional tests in Travis. I was unable to replicate this locally. It passed in PR but failed on merge which is weird.

```
1) Popup Embed Widget Mobile Closes the Drawer widget clicking on close Button:
     Uncaught TypeError: Cannot read property 'style' of null
This error originated from your application code, not from Cypress.
When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
This behavior is configurable, and you can choose to turn this off by listening to the 'uncaught:exception' event.
https://on.cypress.io/uncaught-exception-from-application
      at eval (webpack-internal:///./src/core/views/components/iframe.js:69:26)
```
The second commit here is explicit merge of `release` branch. When I opened PR from `master` to `release` it said the branch is out of sync but the merge commit is empty 🤷‍♂️ This should resolve it.