### PR TITLE
fix: Publish to both registries

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,12 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
+    [
+      "@semantic-release/exec",
+      {
+        "successCmd": "yarn run publish:github"
+      }
+    ],
     "@semantic-release/git",
     "@semantic-release/github"
   ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "copy:demo": "yarn copyfiles -f demo/* dist",
     "build": "yarn run dist && yarn run lib && yarn run copy",
     "dist": "yarn run clean:dist && yarn webpack --config webpack.config.dist.js",
-    "lib": "yarn run clean:lib && yarn webpack --config webpack.config.lib.js"
+    "lib": "yarn run clean:lib && yarn webpack --config webpack.config.lib.js",
+    "publish:github": "npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN && npm publish --registry https://npm.pkg.github.com"
   },
   "devDependencies": {
     "@applitools/eyes-webdriverio": "^5.7.2",
@@ -50,6 +51,7 @@
     "@commitlint/config-conventional": "^8.3.4",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
+    "@semantic-release/exec": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.0.6",
     "@semantic-release/npm": "^7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,18 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-2.2.0.tgz#ee9d5a09c9969eade1ec864776aeda5c5cddbbf0"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
 
+"@semantic-release/exec@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-5.0.0.tgz#69c253107a755dabf7c262d417269d099f714356"
+  integrity sha512-t7LWXIvDJQbuGCy2WmMG51WyaGSLTvZBv9INvcI4S0kn+QjnnVVUMhcioIqhb0r3yqqarMzHVcABFug0q0OXjw==
+  dependencies:
+    "@semantic-release/error" "^2.1.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    lodash "^4.17.4"
+    parse-json "^5.0.0"
+
 "@semantic-release/git@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-9.0.0.tgz#304c4883c87d095b1faaae93300f1f1e0466e9a5"


### PR DESCRIPTION
We have this [big epic](https://jira.typeform.tf/browse/FEAR-25). Basically the idea is to migrate all `npm` packages from `npm` registry to `GitHub` registry, so that nobody needs to go and create own personal `npm` tokens which we cannot dispose even if a person already left Typeform, because we don't know which `npm` token belongs to whom. So we need to migrate all existing packages to GitHub registry + publish to both registries, until the migration is finished and we can just remove all tokens from npm. Then everyone should setup their local env and repos to fetch `@typeform/` packages from `GitHub` registry. However, with Open Source libraries it's different because we need them to be published to `npm`, but be accessible for us (those who use `GitHub` registry for `@typeform` packages). So we need to publish to both registries. Initially we wanted to go with a common config for public packages (to avoid any confusions for future OS libraries, but it seems too complicated with `travis`, so we're going to update `travis` configs to publish to both registries manually.