### PR TITLE
chore(DIST-242): Use Jarvis to deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,8 @@ jobs:
       script:
         - yarn build
         - pip install --user awscli
-        - aws s3 cp ./dist s3://$AWS_ASSETS_BUCKET/$TRAVIS_COMMIT --recursive --acl public-read
-        - ./scripts/comment-preview-link
+        - yarn add @typeform/jarvis
+        - DEBUG=jarvis yarn run jarvis deploy --path dist --preview --notify-preview
     - name: "Release to NPM"
       if: branch = master AND type = push
       script:
@@ -93,4 +93,5 @@ jobs:
       script:
         - yarn build
         - pip install --user awscli
-        - aws s3 cp ./dist s3://$AWS_ASSETS_BUCKET --recursive --acl public-read
+        - yarn add @typeform/jarvis
+        - DEBUG=jarvis jarvis deploy --path dist

--- a/scripts/comment-preview-link
+++ b/scripts/comment-preview-link
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-curl -H "Authorization: token ${GH_TOKEN}" -X POST \
--d "{\"body\": \"Embed script preview available: https://embed.typeform.com/${TRAVIS_COMMIT}/embed.js\"}" \
-"https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"


### PR DESCRIPTION
Install [Jarvis](https://github.com/Typeform/jarvis) package in Travis deploy job and use it for deployment to AWS. Since [Jarvis](https://github.com/Typeform/jarvis) is a private package we do not add it to dependencies in `package.json` or the installation for people from outside of the company would fail. It is installed only in the Travis CI deploy job and changes are not committed.