### PR TITLE
fix(DIST-304): Read @Typeform packages from Github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ before_install:
   - export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY
   - export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_KEY
   - npm config set '//registry.npmjs.org/:_authToken' ${NPM_TOKEN}
+  - npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
+  - npm config set @typeform:registry https://npm.pkg.github.com/
 
 jobs:
   include:


### PR DESCRIPTION
Embed lib does not have any proprietary @typeform packages as dependency. It installs @typeform/jarvis in Travis CI for deployment but it is not saved.
