### PR TITLE
fix(DIST-304): Rerelease the package

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -10,7 +10,7 @@
     [
       "@semantic-release/exec",
       {
-        "successCmd": "yarn run publish:github"
+        "successCmd": "npm publish --registry https://registry.npmjs.org"
       }
     ],
     "@semantic-release/git",

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.6"
 
 addons:
-# https://stackoverflow.com/questions/57903415/travis-ci-chrome-62-instead-of-77
+  # https://stackoverflow.com/questions/57903415/travis-ci-chrome-62-instead-of-77
   chrome: stable
   firefox: "67.0"
 
@@ -36,7 +36,7 @@ before_install:
   - export APPLITOOLS_BATCH_ID=`echo ${TRAVIS_PULL_REQUEST_SHA:=$TRAVIS_COMMIT}`
   - export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY
   - export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_KEY
-  - npm config set '//registry.npmjs.org/:_authToken' ${NPM_TOKEN}
+  - npm config set '//registry.npmjs.org/:_authToken' $NPM_TOKEN
   - npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
   - npm config set @typeform:registry https://npm.pkg.github.com/
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "test:functional:run": "yarn cypress run --spec e2e/spec/functional/**/*",
     "test:debug": "yarn cypress open",
     "prepublish": "yarn run build",
-    "travis-deploy-once": "yarn travis-deploy-once --pro",
-    "publish:github": "npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN && npm publish --registry https://npm.pkg.github.com"
+    "travis-deploy-once": "yarn travis-deploy-once --pro"
   },
   "devDependencies": {
     "@applitools/eyes-cypress": "^3.12.0",


### PR DESCRIPTION
New flow:

- installs tokens
- sets default registry for @typeform packages to be github
- installs private packages
- publishes to GitHub
- `semantic-release/exec` picks it up and runs `npm publish` for npm registry