### PR TITLE
fix(DIST-269): Fix autofocus of full-screen form in Safari

### DIFF
--- a/src/core/make-fullscreen.js
+++ b/src/core/make-fullscreen.js
@@ -28,6 +28,7 @@ export default function makeFullScreen (iframe, url, options) {
   }
 
   iframe.src = appendParamsToUrl(url, replaceExistingKeys(options, queryStringKeys))
+  iframe.focus()
 
   const onFormSubmit = (event) => {
     options.onSubmit(getSubmitEventData(event))


### PR DESCRIPTION
Bug [DIST-269](https://jira.typeform.tf/browse/DIST-269) in Safari is solved by code inspired by #53 from @prilutskiy 