### PR TITLE
fix(DIST-351): Add box shadow to side panel popup

### DIFF
--- a/src/core/views/popup.js
+++ b/src/core/views/popup.js
@@ -94,6 +94,7 @@ const popoverWrapper = styled(BaseWrapper)`
 const sidePanelWrapper = styled.div`
   width: ${p => p.width}px;
   height: ${p => p.height}px;
+  box-shadow: rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;
 `
 
 const BaseCloseImage = styled.img`


### PR DESCRIPTION
When a white typeform is embedded in a white page the box shadow separates the form:
![Screenshot 2020-07-21 at 16 26 17](https://user-images.githubusercontent.com/1561771/88067327-24f3fe80-cb6f-11ea-9c47-568a318fd3db.png)
