### PR TITLE
PI-81 Add option to transfer parameters from url to embed as hidden field

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ typeformEmbed.makeWidget(element, url, options)
   | hideHeaders    | Hide typeform header, that appears when you have a Question group, or a long question that you need to scroll through to answer, like a Multiple Choice block. | `Boolean`  | false   |
   | onSubmit       | Callback function that will be executed right after the typeform is successfully submitted.                                                                    | `Function` | -       |
   | onReady        | Callback function that will be executed once the typeform is ready.                                                                                            | `Function` | -       |
-
+    | transferableUrlParameters     | Parameters that we want to transfert from the URL to the Typeform as hidden fields | `Array`   | [] |
   #### Example:
 
   ```js
@@ -121,6 +121,7 @@ typeformEmbed.makePopup(url, options)
   | onReady        | Callback function that will be executed once the typeform is ready.                                                                                            | `Function`                                                                    | -       |
   | onClose        | Callback function that will be executed once the typeform is closed.                                                                                           | `Function`                                                                    | -       |
   | container      | Element to place the popup into. Optional. Required only for `"side_panel"` mode.                                                                              | `DOM element`                                                                 | -       |
+      | transferableUrlParameters     | Parameters that we want to transfert from the URL to the Typeform as hidden fields | `Array`   | [] |
 
 Types:
 

--- a/demo/popup-api.html
+++ b/demo/popup-api.html
@@ -134,17 +134,17 @@
       window.addEventListener('DOMContentLoaded', function () {
         document.getElementById('btn-popup').onclick = function(e) {
           e.preventDefault()
-          makeMockPopup({mode: 'popup'}).open()
+          makeMockPopup({mode: 'popup', transferableUrlParameters: ['utm_source']}).open()
         }
 
         document.getElementById('btn-drawer_left').onclick = function(e) {
           e.preventDefault()
-          makeMockPopup({mode: 'drawer_left'}).open()
+          makeMockPopup({mode: 'drawer_left', transferableUrlParameters: ['utm_source']}).open()
         }
 
         document.getElementById('btn-drawer_right').onclick = function(e) {
           e.preventDefault()
-          makeMockPopup({mode: 'drawer_right', width: 300}).open()
+          makeMockPopup({mode: 'drawer_right', width: 300, transferableUrlParameters: ['utm_source']}).open()
         }
 
         let popoverPopup
@@ -164,6 +164,7 @@
               mode: 'popover',
               width: 400,
               height: 400,
+              transferableUrlParameters: ['utm_source'],
               onReady: popoverReadyCallback
             })
             popoverButton.innerHTML = '...'
@@ -202,6 +203,7 @@
               mode: 'side_panel',
               width: 400,
               height: 400,
+              transferableUrlParameters: ['utm_source'],
               container: sidePanelContainerElement,
               onReady: sidePanelReadyCallback
             })

--- a/demo/popup.html
+++ b/demo/popup.html
@@ -95,6 +95,7 @@
       href="./form/mock.html#foobar=hello"
       data-mode="popup"
       data-submit-close-delay="4"
+      data-transferable-url-parameters="utm_source"
       target="_blank"
     >
       Launch me as a popup!
@@ -107,6 +108,7 @@
       href="./form/mock.html?foobar=hello"
       data-mode="drawer_left"
       data-submit-close-delay="4"
+      data-transferable-url-parameters="utm_source"
       target="_blank"
     >
       Launch me as a drawer!
@@ -119,6 +121,7 @@
       data-mode="drawer_right"
       data-width="400"
       data-submit-close-delay="4"
+      data-transferable-url-parameters="utm_source"
       target="_blank"
     >
       Launch me as a right drawer!
@@ -134,6 +137,7 @@
       data-width="500"
       data-height="600"
       data-submit-close-delay="4"
+      data-transferable-url-parameters="utm_source"
       target="_blank"
     >
       <span class="icon">
@@ -155,6 +159,7 @@
         data-width="360"
         data-height="560"
         data-submit-close-delay="4"
+        data-transferable-url-parameters="utm_source"
         target="_blank"
       >
         <span class="icon">

--- a/demo/widget-legacy.html
+++ b/demo/widget-legacy.html
@@ -10,6 +10,7 @@
     <div
       class="typeform-widget"
       data-url="./form/mock.html?foobar=hello"
+      data-transferable-url-parameters="utm_source"
       style="width:100%; height:500px;"
     ></div>
 

--- a/demo/widget.html
+++ b/demo/widget.html
@@ -10,6 +10,7 @@
     <div
       class="typeform-widget"
       data-url="./form/mock.html#foobar=hello"
+      data-transferable-url-parameters="utm_source"
       style="width:100%; height:500px;"
     ></div>
 

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -17,8 +17,8 @@ const popupModes = {
 }
 
 const pages = {
-  '/popup.html': 'embed code',
-  '/popup-api.html': 'API'
+  '/popup.html?utm_source=facebook  ': 'embed code',
+  '/popup-api.html?utm_source=facebook': 'API'
 }
 
 Object.keys(popupModes).forEach(popupMode => {
@@ -33,6 +33,10 @@ Object.keys(popupModes).forEach(popupMode => {
 
           it('Passes hidden field parameter', () => {
             cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /foobar=hello/)
+          })
+
+          it('Passes Browser URL parameters', () => {
+            cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /utm_source=facebook/)
           })
 
           it('Closes Embed Popup clicking on the close button', () => {

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -10,7 +10,7 @@ describe('Embed Widget in div with position:absolute on mobile', () => {
 describe('Basic Embed Widget', () => {
   describe('On Desktop', () => {
     before(() => {
-      open('/widget.html')
+      open('/widget.html?utm_source=facebook')
     })
 
     it('Loads correctly the basic embed widget', () => {
@@ -20,11 +20,15 @@ describe('Basic Embed Widget', () => {
     it('Passes hidden field parameter', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /foobar=hello/)
     })
+
+    it('Passes Browser URL parameters', () => {
+      cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /utm_source=facebook/)
+    })
   })
 
   describe('On Mobile', () => {
     before(() => {
-      openOnMobile('/widget.html')
+      openOnMobile('/widget.html?utm_source=facebook')
     })
 
     it('Loads correctly the basic embed widget', () => {
@@ -33,6 +37,10 @@ describe('Basic Embed Widget', () => {
 
     it('Passes hidden field parameter', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /foobar=hello/)
+    })
+
+    it('Passes Browser URL parameters', () => {
+      cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /utm_source=facebook/)
     })
   })
 })
@@ -40,7 +48,7 @@ describe('Basic Embed Widget', () => {
 describe('Basic Embed Widget with Legacy Hidden Fields', () => {
   describe('On Desktop', () => {
     before(() => {
-      open('/widget-legacy.html')
+      open('/widget-legacy.html?utm_source=facebook')
     })
 
     it('Loads correctly the basic embed widget', () => {
@@ -50,11 +58,15 @@ describe('Basic Embed Widget with Legacy Hidden Fields', () => {
     it('Passes hidden field parameter', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /foobar=hello/)
     })
+
+    it('Passes Browser URL parameters', () => {
+      cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /utm_source=facebook/)
+    })
   })
 
   describe('On Mobile', () => {
     before(() => {
-      openOnMobile('/widget-legacy.html')
+      openOnMobile('/widget-legacy.html?utm_source=facebook')
     })
 
     it('Loads correctly the basic embed widget', () => {
@@ -63,6 +75,10 @@ describe('Basic Embed Widget with Legacy Hidden Fields', () => {
 
     it('Passes hidden field parameter', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /foobar=hello/)
+    })
+
+    it('Passes Browser URL parameters', () => {
+      cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /utm_source=facebook/)
     })
   })
 })

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -18,6 +18,10 @@ const transformLegacyDataMode = dataMode => {
   return element ? element.mode : dataMode
 }
 
+const parseTransferableUrlParameters = transferableUrlParameters => {
+  return transferableUrlParameters.replace(/ /g, '').split(',')
+}
+
 const getDataset = element => {
   const data = {}
   ;[].forEach.call(element.attributes, attr => {
@@ -73,6 +77,10 @@ const sanitizePopupAttributes = data => {
     obj.height = parseInt(data.height, 10)
   }
 
+  if (data.transferableUrlParameters) {
+    obj.transferableUrlParameters = parseTransferableUrlParameters(data.transferableUrlParameters)
+  }
+
   return obj
 }
 
@@ -98,6 +106,10 @@ const sanitizeWidgetAttributes = data => {
 
   if (data.buttonText) {
     obj.buttonText = data.buttonText
+  }
+
+  if (data.transferableUrlParameters) {
+    obj.transferableUrlParameters = parseTransferableUrlParameters(data.transferableUrlParameters)
   }
 
   return obj

--- a/src/core/attributes.spec.js
+++ b/src/core/attributes.spec.js
@@ -42,6 +42,12 @@ describe('Attributes', () => {
         mode: 'drawer_right'
       })
     })
+
+    it('takes in account the data-transferable-url-parameters option and parse the options correctly', () => {
+      const mockElement = document.createElement('div')
+      mockElement.setAttribute('data-transferable-url-parameters', 'foo, bar,  john')
+      expect(sanitizePopupAttributes(getDataset(mockElement))).toEqual({ transferableUrlParameters: ['foo', 'bar', 'john'] })
+    })
   })
 
   describe('Widget', () => {
@@ -60,6 +66,12 @@ describe('Attributes', () => {
       }
 
       expect(sanitizeWidgetAttributes(getDataset(widgetMockElem))).toEqual(widgetOptions)
+    })
+
+    it('takes in account the data-transferable-url-parameters option and parse the options correctly', () => {
+      const widgetMockElem = document.createElement('div')
+      widgetMockElem.setAttribute('data-transferable-url-parameters', ' foo,   bar,  john')
+      expect(sanitizeWidgetAttributes(getDataset(widgetMockElem))).toEqual({ transferableUrlParameters: ['foo', 'bar', 'john'] })
     })
   })
 })

--- a/src/core/make-popup.js
+++ b/src/core/make-popup.js
@@ -7,6 +7,9 @@ import {
   ensureMetaViewport,
   noop
 } from './utils'
+import {
+  transferUrlParametersToQueryStrings
+} from './utils/url-parameters-transfer'
 import randomString from './utils/random-string'
 import {
   isMobile,
@@ -45,6 +48,7 @@ const buildOptions = (embedId, options) => {
     hideHeaders: false,
     hideScrollbars: false,
     disableTracking: false,
+    transferableUrlParameters: options.transferableUrlParameters || [],
     onSubmit: noop,
     open: null,
     openValue: null,
@@ -72,9 +76,12 @@ const renderComponent = (params, options) => {
     onSubmit
   } = options
 
+  let queryStrings = replaceExistingKeys(options, queryStringKeys)
+  queryStrings = transferUrlParametersToQueryStrings(options.transferableUrlParameters, queryStrings)
+
   const urlWithQueryString = appendParamsToUrl(
     url,
-    replaceExistingKeys(options, queryStringKeys)
+    queryStrings
   )
 
   if (!isMobile(navigator.userAgent) && isScreenBig()) {

--- a/src/core/make-widget.js
+++ b/src/core/make-widget.js
@@ -8,6 +8,9 @@ import {
   omit
 } from './utils'
 import {
+  transferUrlParametersToQueryStrings
+} from './utils/url-parameters-transfer'
+import {
   isMobile
 } from './utils/mobile-detection'
 import Widget from './views/widget'
@@ -19,6 +22,7 @@ const defaultOptions = {
   hideHeaders: false,
   hideScrollbars: false,
   disableTracking: false,
+  transferableUrlParameters: [],
   onSubmit: noop
 }
 
@@ -38,6 +42,7 @@ export default function makeWidget (element, url, options) {
   const enabledFullscreen = isMobile(navigator.userAgent)
 
   let queryStrings = replaceExistingKeys(options, queryStringKeys)
+  queryStrings = transferUrlParametersToQueryStrings(options.transferableUrlParameters, queryStrings)
 
   if (enabledFullscreen) {
     queryStrings = {

--- a/src/core/utils/url-parameters-transfer.js
+++ b/src/core/utils/url-parameters-transfer.js
@@ -1,0 +1,23 @@
+const urlSearchToParams = (search) => {
+  var params = {}
+  if (search !== '' && search !== null) {
+    var vars = search.split('&')
+    for (var i = 0; i < vars.length; i++) {
+      var pair = vars[i].split('=')
+      params[pair[0]] = decodeURIComponent(pair[1])
+    }
+  }
+  return params
+}
+
+export const transferUrlParametersToQueryStrings = (transferableUrlParameters, queryStrings) => {
+  const urlSearchString = window.location.search.substr(1)
+  const urlSearchParams = urlSearchToParams(urlSearchString)
+  const queryStringsWithTransferedParams = { ...queryStrings }
+  transferableUrlParameters.forEach(transferableParam => {
+    if (!(transferableParam in queryStrings)) {
+      queryStringsWithTransferedParams[transferableParam] = urlSearchParams[transferableParam]
+    }
+  })
+  return queryStringsWithTransferedParams
+}

--- a/src/core/utils/url-parameters-transfer.spec.js
+++ b/src/core/utils/url-parameters-transfer.spec.js
@@ -1,0 +1,32 @@
+import { transferUrlParametersToQueryStrings } from './url-parameters-transfer'
+
+describe('transferUrlParametersToQueryStrings', () => {
+  const { location } = window
+
+  beforeAll(() => {
+    delete window.location
+    window.location = { search: '?foo=jason&bar=rachel&utm_medium=cpc&utm_campaign=camp2008&utm_source=instagram&embed-hide-footer=false' }
+  })
+
+  afterAll(() => {
+    window.location = location
+  })
+
+  it('should return ?foo=jason&bar=rachel&utm_medium=cpc&utm_campaign=camp2008&utm_source=instagram&embed-hide-footer=false', () => {
+    expect(window.location.search).toEqual('?foo=jason&bar=rachel&utm_medium=cpc&utm_campaign=camp2008&utm_source=instagram&embed-hide-footer=false')
+  })
+
+  it('transfer the parameters of the URL in the query strings', () => {
+    const urlParameters = ['foo', 'bar']
+    const queryStrings = {}
+    const queryStringWithTransferedUrlParameters = transferUrlParametersToQueryStrings(urlParameters, queryStrings)
+    expect(queryStringWithTransferedUrlParameters).toEqual({ foo: 'jason', bar: 'rachel' })
+  })
+
+  it('does not override existing queryString for embed configuration', () => {
+    const urlParameters = ['foo', 'bar', 'embed-hide-footer']
+    const queryStrings = { 'embed-hide-footer': true }
+    const queryStringWithTransferedUrlParameters = transferUrlParametersToQueryStrings(urlParameters, queryStrings)
+    expect(queryStringWithTransferedUrlParameters).toEqual({ foo: 'jason', bar: 'rachel', 'embed-hide-footer': true })
+  })
+})


### PR DESCRIPTION
# Motivation for this change

The motivation of this change is to make it easier for Typeform users to pass specific dynamic parameters from the URL of the website they embed a Typeform into, to their Typeform. 

- Example 1: you have a website with a Typeform embedded in it, you users see ad on Instagram to your website, the user is directed to your website with a ```utm_source=instagram``` parameter, you set this `transferableUrlParameter` in the Typeform embed API and create a hidden field in your Typeform configuration, your Typeform is connected to Google sheet integration and you can now see where your users who completed the Typeform came from.

- Example 2: You want to personalize the Typeform displayed on the website dynamically to display contextual information like the name of the person filling the form if you know it in advance.

# How to use this feature

First, the Typeform user needs to add hidden fields for the parameters in the settings of the Typeform.
Then, you need to set the URL parameters you want to transfer to the Typeform in the embed API:

In an HTML snippet using the embed:

```html
<div
      class="typeform-widget"
      data-url="mytypeformURL"
      data-transferable-url-parameters="utm_source, utm_medium"
    ></div>
<script type="text/javascript" src="https://embed.typeform.com/embed.js"></script>
```

Using the API: 

```js

const embedElement = document.querySelector('.js-typeform-embed')

typeformEmbed.makeWidget(
  embedElement,
  'https://admin.typeform.com/to/PlBzgL',
  {
    buttonText: "Answer this!",
    transferableUrlParameters: ['utm_source', 'utm_medium'],
  }
)
```


# Test plan

- Unit tests to check that the embedded html snippet parse properly the ```data-transferable-url-parameters``` to the widget and popup api: https://github.com/Typeform/embed/commit/87b782414127d154c041bf04161925fa9ff53c86
- Unit tests to test the transfer of parameters in URL: https://github.com/Typeform/embed/compare/PI-81_Add_Option_To_Transfer_Parameters_From_Url?expand=1#diff-243c10e837412d06d08c6b0a0c936af8
- End to end tests to test the entire feature from embed and API perspective for the popup and widget: https://github.com/Typeform/embed/commit/5531870994fdd5ccf0c203c7642b0f2d67e46b1f

# Issue link

- https://jira.typeform.tf/browse/PI-81
