### PR TITLE
PI-89 Add shareGoogleAnalyticsInstance option feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ typeformEmbed.makeWidget(element, url, options)
   | hideHeaders    | Hide typeform header, that appears when you have a Question group, or a long question that you need to scroll through to answer, like a Multiple Choice block. | `Boolean`  | false   |
   | onSubmit       | Callback function that will be executed right after the typeform is successfully submitted.                                                                    | `Function` | -       |
   | onReady        | Callback function that will be executed once the typeform is ready.                                                                                            | `Function` | -       |
-    | transferableUrlParameters     | Parameters that we want to transfert from the URL to the Typeform as hidden fields | `Array`   | [] |
+  | transferableUrlParameters     | Parameters that we want to transfert from the URL to the Typeform as hidden fields | `Array`   | [] |
+  | shareGoogleAnalyticsInstance | Allows to share the Google instance of the page with the Typeform in the embed | `Boolean`   | false |
   #### Example:
 
   ```js

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ typeformEmbed.makePopup(url, options)
   | onReady        | Callback function that will be executed once the typeform is ready.                                                                                            | `Function`                                                                    | -       |
   | onClose        | Callback function that will be executed once the typeform is closed.                                                                                           | `Function`                                                                    | -       |
   | container      | Element to place the popup into. Optional. Required only for `"side_panel"` mode.                                                                              | `DOM element`                                                                 | -       |
-      | transferableUrlParameters     | Parameters that we want to transfert from the URL to the Typeform as hidden fields | `Array`   | [] |
+  | shareGoogleAnalyticsInstance | Allows to share the Google instance of the page with the Typeform in the embed | `Boolean`   | false |
 
 Types:
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,9 +16,11 @@
       <li><a href="./widget.html">Widget *</a></li>
       <li><a href="./widget-legacy.html">Widget with legacy hidden fields *</a></li>
       <li><a href="./widget-v2.html">Widget with long text</a></li>
+      <li><a href="./widget-with-share-google-analytics-instance-option.html">Widget with shareGoogleAnalyticsInstance option</a></li>
       <li><a href="./multi-widget.html">Multiple widgets</a></li>
       <li><a href="./full.html">Full page *</a></li>
       <li><a href="./popup.html">Popups *</a></li>
+      <li><a href="./popup-with-share-google-analytics-instance-option.html">Popup with shareGoogleAnalyticsInstance option</a></li>
       <li><a href="./popup-and-widget.html">Popup and widget</a></li>
       <li><a href="./absolute.html">Widget in absolutely positioned element *</a></li>
     </ul>
@@ -37,6 +39,7 @@
       <li><a href="./widget-api.html">Widget</a></li>
       <li><a href="./fullpage-api.html">Full page</a></li>
       <li><a href="./popup-api.html">Popup *</a></li>
+      <li><a href="./popup-api-with-share-google-analytics-instance-option.html">Popup API with shareGoogleAnalyticsInstance option</a></li>
       <li><a href="./popup-api-autoopen.html">Popup (with auto open)</a></li>
       <li><a href="./popup-api-container.html">Popup inside container</a></li>
     </ul>

--- a/demo/popup-api-with-share-google-analytics-instance-option.html
+++ b/demo/popup-api-with-share-google-analytics-instance-option.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Popup example</title>
+    <link rel="stylesheet" href="demo.css" />
+    <!-- Google Analytics Debug instance -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics_debug.js','ga');
+    
+      ga('create', 'UA-XXXXX-Y', 'auto');
+      if (location.hostname == 'localhost') {
+        // This disables network interraction with Google Analytics
+        ga('set', 'sendHitTask', null);
+      }
+      ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics Debug instance -->
+    <style type="text/css">
+      a.popup {
+        margin: 20px 0;
+        display: block;
+        color: #427fed;
+        cursor: pointer;
+        text-decoration: underline;
+      }
+
+      /* CSS for wrapper is required */
+      .side-panel-wrapper {
+        top: calc(50% - 300px); /* needs to be set manually based on popup size */
+        right: 0;
+        position: fixed;
+        transition: width 300ms ease-out;
+        width: 0;
+      }
+
+      .side-panel {
+        position: absolute;
+        top: 300px; /* needs to be set manually based on button size */
+        width: 300px; /* needs to be set manually based on button size */
+        height: 40px;
+        background: #427fed;
+        color: white;
+        padding: 0 20px;
+        margin: 0;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transform: rotate(-90deg);
+        transform-origin: bottom left;
+      }
+
+      .side-panel > .icon {
+        position: relative;
+        align-items: center;
+        justify-content: center;
+        display: flex;
+        width: 40px;
+        height: 40px;
+        margin-right: 10px;
+      }
+
+      .side-panel > .icon > svg {
+        transform-origin: left;
+        transform: translate(10px,-15px) rotate(90deg)
+      }
+
+      .popover {
+        width: 54px;
+        height: 54px;
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        background: #427fed;
+        color: white;
+      }
+
+      .popover > .icon {
+        align-items: center;
+        justify-content: center;
+        display: flex;
+      }
+
+      .popover-hint, .side-panel-hint {
+        color: darkgray;
+        position: fixed;
+        right: 90px;
+        bottom: 16px;
+        height: 54px;
+        line-height: 54px;
+      }
+
+      .side-panel-hint {
+        bottom: auto;
+        top: calc(50% - 200px);
+        right: 60px;
+      }
+    </style>
+  </head>
+  <body>
+    <a id="btn-popup" class="popup">Launch me as a popup!</a>
+
+    <a id="btn-drawer_left" class="popup">Launch me as a drawer!</a>
+
+    <a id="btn-drawer_right" class="popup">Launch me as a right drawer!</a>
+
+    <div class="popover-hint">Launch a popover here 👉</div>
+
+    <a id="btn-popover" class="popover">
+      <span class="icon">
+        <svg width="24" height="24" fill="none" style="margin-top:7px" viewBox="0 0 84 83">
+          <rect width="84" height="56" fill="#fff" rx="8" />
+          <path fill="#fff" d="M43 50h41v33L43 50z" opacity=".7" />
+        </svg>
+      </span>
+    </a>
+
+    <div class="side-panel-hint">Side panel 👉</div>
+
+    <div class="side-panel-wrapper">
+      <a id="btn-side_panel" class="side-panel">
+        <span class="icon">
+          <svg width="24" height="24" fill="none" style="margin-top:7px" viewBox="0 0 84 83">
+            <rect width="84" height="56" fill="#fff" rx="8" />
+            <path fill="#fff" d="M43 50h41v33L43 50z" opacity=".7" />
+          </svg>
+        </span>
+        Launch me as a side panel!
+      </a>
+    </div>
+
+    <script type="text/javascript" src="embed.js"></script>
+    <script type="text/javascript" src="demo.js"></script>
+
+    <script>
+      function makeMockPopup(options = {}) {
+        return window.typeformEmbed.makePopup('./form/mock.html#foobar=hello', options)
+      }
+      window.addEventListener('DOMContentLoaded', function () {
+        document.getElementById('btn-popup').onclick = function(e) {
+          e.preventDefault()
+          makeMockPopup({mode: 'popup', shareGoogleAnalyticsInstance: true, }).open()
+        }
+
+        document.getElementById('btn-drawer_left').onclick = function(e) {
+          e.preventDefault()
+          makeMockPopup({mode: 'drawer_left', shareGoogleAnalyticsInstance: true, }).open()
+        }
+
+        document.getElementById('btn-drawer_right').onclick = function(e) {
+          e.preventDefault()
+          makeMockPopup({mode: 'drawer_right', width: 300, shareGoogleAnalyticsInstance: true, }).open()
+        }
+
+        let popoverPopup
+        const popoverButton = document.getElementById('btn-popover')
+        const popoverButtonIcon = popoverButton.innerHTML
+        const popoverReadyCallback = function () {
+          setTimeout(function() {
+            popoverButton.innerHTML = '&#10005;'
+          }, 500)
+        }
+
+        popoverButton.onclick = function(e) {
+          e.preventDefault()
+
+          if (!popoverPopup) {
+            popoverPopup = makeMockPopup({
+              mode: 'popover',
+              width: 400,
+              height: 400,
+              shareGoogleAnalyticsInstance: true,
+              onReady: popoverReadyCallback
+            })
+            popoverButton.innerHTML = '...'
+            popoverPopup.open()
+          } else {
+            popoverPopup.close()
+            popoverPopup = null
+            popoverButton.innerHTML = popoverButtonIcon
+          }
+        }
+
+        let sidePanelPopup
+        const sidePanelButton = document.getElementById('btn-side_panel')
+        const sidePanelButtonContent = sidePanelButton.innerHTML
+        const sidePanelReadyCallback = function () {
+          setTimeout(function() {
+            sidePanelButton.innerHTML = 'CLOSE'
+          }, 500)
+        }
+
+        /**
+         * Side panel popup needs to be displayed inside a container.
+         * This enables
+         *
+         * The container:
+         *   - needs to be direct parent of the button
+         *   - needs to have correct styles (see `.side-panel-wrapper` styles)
+         */
+        const sidePanelContainerElement = document.querySelector('.side-panel-wrapper')
+
+        sidePanelButton.onclick = function(e) {
+          e.preventDefault()
+
+          if (!sidePanelPopup) {
+            sidePanelPopup = makeMockPopup({
+              mode: 'side_panel',
+              width: 400,
+              height: 400,
+              shareGoogleAnalyticsInstance: true,
+              container: sidePanelContainerElement,
+              onReady: sidePanelReadyCallback
+            })
+            sidePanelButton.innerHTML = 'LOADING...'
+            sidePanelPopup.open()
+          } else {
+            sidePanelContainerElement.style.width = 0
+            sidePanelButton.innerHTML = 'CLOSING...'
+              setTimeout(function() {
+              sidePanelPopup.close()
+              sidePanelPopup = null
+              sidePanelButton.innerHTML = sidePanelButtonContent
+            }, 500) // handle closing animation manually
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/demo/popup-with-share-google-analytics-instance-option.html
+++ b/demo/popup-with-share-google-analytics-instance-option.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Popup example</title>
+    <link rel="stylesheet" href="demo.css" />
+    <!-- Google Analytics Debug instance -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics_debug.js','ga');
+    
+      ga('create', 'UA-XXXXX-Y', 'auto');
+      if (location.hostname == 'localhost') {
+        // This disables network interraction with Google Analytics
+        ga('set', 'sendHitTask', null);
+      }
+      ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics Debug instance -->
+    <style type="text/css">
+      a.popup {
+        margin: 20px 0;
+        display: block;
+      }
+
+      /* CSS for wrapper is required */
+      .side-panel-wrapper {
+        top: calc(50% - 300px); /* needs to be set manually based on popup size */
+        right: 0;
+        position: fixed;
+        transition: width 300ms ease-out;
+        width: 0;
+      }
+
+      .side-panel {
+        position: absolute;
+        top: 300px; /* needs to be set manually based on button size */
+        width: 300px; /* needs to be set manually based on button size */
+        height: 40px;
+        background: #427fed;
+        color: white;
+        padding: 0 20px;
+        margin: 0;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transform: rotate(-90deg);
+        transform-origin: bottom left;
+      }
+
+      .side-panel > .icon {
+        position: relative;
+        align-items: center;
+        justify-content: center;
+        display: flex;
+        width: 40px;
+        height: 40px;
+        margin-right: 10px;
+      }
+
+      .side-panel > .icon > svg {
+        transform-origin: left;
+        transform: translate(10px,-15px) rotate(90deg)
+      }
+
+      .popover {
+        width: 54px;
+        height: 54px;
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        background: #427fed;
+      }
+
+      .popover > .icon {
+        align-items: center;
+        justify-content: center;
+        display: flex;
+      }
+
+      .popover-hint, .side-panel-hint {
+        color: darkgray;
+        position: fixed;
+        right: 90px;
+        bottom: 16px;
+        height: 54px;
+        line-height: 54px;
+      }
+
+      .side-panel-hint {
+        bottom: auto;
+        top: calc(50% - 200px);
+        right: 60px;
+      }
+    </style>
+  </head>
+  <body>
+    <a
+      id="btn-popup"
+      class="typeform-share popup"
+      href="./form/mock.html#foobar=hello"
+      data-mode="popup"
+      data-submit-close-delay="4"
+      class="typeform-share popup"
+      data-share-google-analytics-instance
+      target="_blank"
+    >
+      Launch me as a popup!
+    </a>
+
+    <!-- uses legacy hidden field in query param -->
+    <a
+      id="btn-drawer_left"
+      class="typeform-share popup"
+      href="./form/mock.html?foobar=hello"
+      data-mode="drawer_left"
+      data-submit-close-delay="4"
+      class="typeform-share popup"
+      data-share-google-analytics-instance
+      target="_blank"
+    >
+      Launch me as a drawer!
+    </a>
+
+    <a
+      id="btn-drawer_right"
+      class="typeform-share popup"
+      href="./form/mock.html#foobar=hello"
+      data-mode="drawer_right"
+      data-width="400"
+      data-submit-close-delay="4"
+      class="typeform-share popup"
+      data-share-google-analytics-instance
+      target="_blank"
+    >
+      Launch me as a right drawer!
+    </a>
+
+    <div class="popover-hint">Launch a popover here 👉</div>
+
+    <a
+      id="btn-popover"
+      class="typeform-share popover"
+      href="./form/mock.html#foobar=hello"
+      data-mode="popover"
+      data-width="500"
+      data-height="600"
+      data-submit-close-delay="4"
+      class="typeform-share popup"
+      data-share-google-analytics-instance
+      target="_blank"
+    >
+      <span class="icon">
+        <svg width="24" height="24" fill="none" style="margin-top:7px" viewBox="0 0 84 83">
+          <rect width="84" height="56" fill="#fff" rx="8" />
+          <path fill="#fff" d="M43 50h41v33L43 50z" opacity=".7" />
+        </svg>
+      </span>
+    </a>
+
+    <div class="side-panel-hint">Side panel 👉</div>
+
+    <div class="side-panel-wrapper">
+      <a
+        id="btn-side_panel"
+        class="typeform-share side-panel"
+        href="./form/mock.html#foobar=hello"
+        data-mode="side_panel"
+        data-width="360"
+        data-height="560"
+        data-submit-close-delay="4"
+        class="typeform-share popup"
+        data-share-google-analytics-instance
+        target="_blank"
+      >
+        <span class="icon">
+          <svg width="24" height="24" fill="none" style="margin-top:7px" viewBox="0 0 84 83">
+            <rect width="84" height="56" fill="#fff" rx="8" />
+            <path fill="#fff" d="M43 50h41v33L43 50z" opacity=".7" />
+          </svg>
+        </span>
+        Launch me as a side panel!
+      </a>
+    </div>
+
+    <script type="text/javascript" src="embed.js"></script>
+    <script type="text/javascript" src="demo.js"></script>
+  </body>
+</html>

--- a/demo/widget-with-share-google-analytics-instance-option.html
+++ b/demo/widget-with-share-google-analytics-instance-option.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Widget. with shareGoogleAnalyticsInstance option</title>
+    <link rel="stylesheet" href="demo.css" />
+  <!-- Google Analytics Debug instance -->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics_debug.js','ga');
+  
+    ga('create', 'UA-XXXXX-Y', 'auto');
+    if (location.hostname == 'localhost') {
+      // This disables network interraction with Google Analytics
+      ga('set', 'sendHitTask', null);
+    }
+    ga('send', 'pageview');
+  </script>
+  <!-- End Google Analytics Debug instance -->
+  </head>
+
+  <body>
+    <div
+    class="typeform-widget"
+    data-url="//betatests.typeform.com/to/Z9k3bK"
+    data-share-google-analytics-instance
+    style="width:100%; height:500px;"
+  ></div>
+
+  <script type="text/javascript" src="embed.js"></script>
+
+    <p>
+      This demo page allows to test the shareGoogleAnalyticsInstance option
+    </p>
+  </body>
+</html>

--- a/e2e/cypress-utils.js
+++ b/e2e/cypress-utils.js
@@ -55,9 +55,9 @@ const setViewport = ({ width, height }) => {
   cy.viewport(width, height)
 }
 
-export const open = (url) => {
+export const open = (url, options = {}) => {
   setViewport(screenSizeDesktop)
-  cy.visit(url)
+  cy.visit(url, options)
 }
 
 export const openOnMobile = (url) => {

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -71,3 +71,32 @@ Object.keys(popupModes).forEach(popupMode => {
     })
   })
 })
+
+const pagesGoogleAnalyticsInstanceSharingFeature = {
+  '/popup-with-share-google-analytics-instance-option.html': 'embed code',
+  '/popup-api-with-share-google-analytics-instance-option.html': 'API'
+}
+
+describe('Popup Widget with shareGoogleAnalyticsInstance option', () => {
+  Object.keys(popupModes).forEach(popupMode => {
+    Object.keys(pagesGoogleAnalyticsInstanceSharingFeature).forEach(pageUrl => {
+      describe(`Embedded using ${pages[pageUrl]} (at ${pageUrl})`, () => {
+        describe('Desktop', () => {
+          before(() => {
+            open(pageUrl, {
+              onBeforeLoad (win) {
+                // start spying
+                cy.spy(win, 'postMessage').as('postMessage')
+              }
+            })
+            openPopup(`#btn-${popupMode}`)
+          })
+
+          it('sends the ga-client-id by postMessage', () => {
+            cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
+          })
+        })
+      })
+    })
+  })
+})

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -95,7 +95,7 @@ describe('Popup Widget with shareGoogleAnalyticsInstance option', () => {
           it('sends the ga-client-id by postMessage', () => {
             cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
           })
-          it('Passes Browser share-google-analytics-instance parameter to the URL', () => {
+          it('Passes Browser share-ga-instance parameter to the URL', () => {
             cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)
           })
         })

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -83,17 +83,8 @@ describe('Popup Widget with shareGoogleAnalyticsInstance option', () => {
       describe(`Embedded using ${pages[pageUrl]} (at ${pageUrl})`, () => {
         describe('Desktop', () => {
           before(() => {
-            open(pageUrl, {
-              onBeforeLoad (win) {
-                // start spying
-                cy.spy(win, 'postMessage').as('postMessage')
-              }
-            })
+            open(pageUrl)
             openPopup(`#btn-${popupMode}`)
-          })
-
-          it('sends the ga-client-id by postMessage', () => {
-            cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
           })
           it('Passes Browser share-ga-instance parameter to the URL', () => {
             cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -93,7 +93,7 @@ describe('Popup Widget with shareGoogleAnalyticsInstance option', () => {
           })
 
           it('sends the ga-client-id by postMessage', () => {
-            cy.get('@postMessage').should('to.be.calledWithMatch', 'ga-client-id')
+            cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
           })
           it('Passes Browser share-ga-instance parameter to the URL', () => {
             cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -95,6 +95,9 @@ describe('Popup Widget with shareGoogleAnalyticsInstance option', () => {
           it('sends the ga-client-id by postMessage', () => {
             cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
           })
+          it('Passes Browser share-google-analytics-instance parameter to the URL', () => {
+            cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)
+          })
         })
       })
     })

--- a/e2e/spec/functional/popup.spec.js
+++ b/e2e/spec/functional/popup.spec.js
@@ -93,7 +93,7 @@ describe('Popup Widget with shareGoogleAnalyticsInstance option', () => {
           })
 
           it('sends the ga-client-id by postMessage', () => {
-            cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
+            cy.get('@postMessage').should('to.be.calledWithMatch', 'ga-client-id')
           })
           it('Passes Browser share-ga-instance parameter to the URL', () => {
             cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -132,7 +132,7 @@ describe('Embed Widget with shareGoogleAnalyticsInstance option', () => {
       })
     })
     it('sends the ga-client-id by postMessage', () => {
-      cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
+      cy.get('@postMessage').should('to.be.calledWithMatch', 'ga-client-id')
     })
     it('Passes Browser share-ga-instance parameter to the URL', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -124,15 +124,7 @@ describe('Full Page Embed Widget', () => {
 describe('Embed Widget with shareGoogleAnalyticsInstance option', () => {
   describe('On Desktop', () => {
     before(() => {
-      open('/widget-with-share-google-analytics-instance-option.html', {
-        onBeforeLoad (win) {
-          // start spying
-          cy.spy(win, 'postMessage').as('postMessage')
-        }
-      })
-    })
-    it('sends the ga-client-id by postMessage', () => {
-      cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
+      open('/widget-with-share-google-analytics-instance-option.html')
     })
     it('Passes Browser share-ga-instance parameter to the URL', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -134,5 +134,8 @@ describe('Embed Widget with shareGoogleAnalyticsInstance option', () => {
     it('sends the ga-client-id by postMessage', () => {
       cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
     })
+    it('Passes Browser share-google-analytics-instance parameter to the URL', () => {
+      cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)
+    })
   })
 })

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -134,7 +134,7 @@ describe('Embed Widget with shareGoogleAnalyticsInstance option', () => {
     it('sends the ga-client-id by postMessage', () => {
       cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
     })
-    it('Passes Browser share-google-analytics-instance parameter to the URL', () => {
+    it('Passes Browser share-ga-instance parameter to the URL', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)
     })
   })

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -132,7 +132,7 @@ describe('Embed Widget with shareGoogleAnalyticsInstance option', () => {
       })
     })
     it('sends the ga-client-id by postMessage', () => {
-      cy.get('@postMessage').should('to.be.calledWithMatch', 'ga-client-id')
+      cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
     })
     it('Passes Browser share-ga-instance parameter to the URL', () => {
       cy.get(IFRAME_SELECTOR).should('have.attr', 'src').and('match', /share-ga-instance/)

--- a/e2e/spec/functional/widget.spec.js
+++ b/e2e/spec/functional/widget.spec.js
@@ -10,7 +10,12 @@ describe('Embed Widget in div with position:absolute on mobile', () => {
 describe('Basic Embed Widget', () => {
   describe('On Desktop', () => {
     before(() => {
-      open('/widget.html?utm_source=facebook')
+      open('/widget.html?utm_source=facebook', {
+        onBeforeLoad (win) {
+          // start spying
+          cy.spy(win, 'postMessage')
+        }
+      })
     })
 
     it('Loads correctly the basic embed widget', () => {
@@ -112,6 +117,22 @@ describe('Full Page Embed Widget', () => {
 
     it('Passes hidden field parameter', () => {
       cy.get(iframe).should('have.attr', 'src').and('match', /foobar=hello/)
+    })
+  })
+})
+
+describe('Embed Widget with shareGoogleAnalyticsInstance option', () => {
+  describe('On Desktop', () => {
+    before(() => {
+      open('/widget-with-share-google-analytics-instance-option.html', {
+        onBeforeLoad (win) {
+          // start spying
+          cy.spy(win, 'postMessage').as('postMessage')
+        }
+      })
+    })
+    it('sends the ga-client-id by postMessage', () => {
+      cy.get('@postMessage').should('to.be.calledWithMatch', { type: 'ga-client-id' })
     })
   })
 })

--- a/src/core/attributes.js
+++ b/src/core/attributes.js
@@ -64,6 +64,10 @@ const sanitizePopupAttributes = data => {
     obj.hideScrollbars = true
   }
 
+  if (data.shareGoogleAnalyticsInstance === '' || data.shareGoogleAnalyticsInstance === 'true') {
+    obj.shareGoogleAnalyticsInstance = true
+  }
+
   if (data.open) {
     obj.open = data.open
     obj.openValue = data.openValue
@@ -97,6 +101,10 @@ const sanitizeWidgetAttributes = data => {
 
   if (data.hideScrollbars === '' || data.hideScrollbars === 'true') {
     obj.hideScrollbars = true
+  }
+
+  if (data.shareGoogleAnalyticsInstance === '' || data.shareGoogleAnalyticsInstance === 'true') {
+    obj.shareGoogleAnalyticsInstance = true
   }
 
   const transparency = parseInt(data.transparency, 10)

--- a/src/core/attributes.spec.js
+++ b/src/core/attributes.spec.js
@@ -15,6 +15,7 @@ describe('Attributes', () => {
       popupMockElem.setAttribute('data-open-value', 20)
       popupMockElem.setAttribute('data-hide-headers', '')
       popupMockElem.setAttribute('data-hide-footer', false)
+      popupMockElem.setAttribute('data-share-google-analytics-instance', true)
       popupMockElem.setAttribute('data-invalid-attribute', true)
 
       const popupOptions = {
@@ -23,7 +24,8 @@ describe('Attributes', () => {
         autoOpen: true,
         open: 'scroll',
         openValue: '20',
-        hideHeaders: true
+        hideHeaders: true,
+        shareGoogleAnalyticsInstance: true
       }
 
       expect(sanitizePopupAttributes(getDataset(popupMockElem))).toEqual(popupOptions)
@@ -57,10 +59,12 @@ describe('Attributes', () => {
       widgetMockElem.setAttribute('data-hide-footer', '')
       widgetMockElem.setAttribute('data-scrollbars', false)
       widgetMockElem.setAttribute('data-invalid-attribute', true)
+      widgetMockElem.setAttribute('data-share-google-analytics-instance', true)
       widgetMockElem.setAttribute('data-transparency', 20)
 
       const widgetOptions = {
         hideHeaders: true,
+        shareGoogleAnalyticsInstance: true,
         hideFooter: true,
         opacity: 100 - 20
       }

--- a/src/core/features/google-analytics-instance-sharing.js
+++ b/src/core/features/google-analytics-instance-sharing.js
@@ -13,6 +13,6 @@ export const setupGoogleAnalyticsInstanceSharingFeature = (embedId) => {
   gaObject(function (tracker) {
     const gaClientId = tracker.get('clientId')
     const message = { embedId, gaClientId }
-    window.postMessage({ type: 'ga-client-id', message }, '*')
+    window.postMessage('ga-client-id', message, '*')
   })
 }

--- a/src/core/features/google-analytics-instance-sharing.js
+++ b/src/core/features/google-analytics-instance-sharing.js
@@ -13,6 +13,7 @@ export const setupGoogleAnalyticsInstanceSharingFeature = (embedId) => {
   gaObject(function (tracker) {
     const gaClientId = tracker.get('clientId')
     const data = { embedId, gaClientId }
-    window.postMessage({ type: 'ga-client-id', data }, '*')
+    const iframeWindow = document.querySelector(`iframe#${embedId}`).contentWindow
+    iframeWindow.postMessage({ type: 'ga-client-id', data }, '*')
   })
 }

--- a/src/core/features/google-analytics-instance-sharing.js
+++ b/src/core/features/google-analytics-instance-sharing.js
@@ -1,0 +1,18 @@
+export const setupGoogleAnalyticsInstanceSharingFeature = (embedId) => {
+  // Throw an error if the feature is enabled but ga is not found
+
+  const gaObject = window[window.GoogleAnalyticsObject]
+
+  if (gaObject === undefined || gaObject === null) {
+    throw new Error(
+      `Whoops! You enabled the shareGoogleAnalyticsInstance feature but the google analytics object has not been found. 
+      Make sure to include Google Analytics Javascript code before the Typeform Embed Javascript code in your page. `
+    )
+  }
+
+  gaObject(function (tracker) {
+    const gaClientId = tracker.get('clientId')
+    const message = { embedId, gaClientId }
+    window.postMessage({ type: 'ga-client-id', message }, '*')
+  })
+}

--- a/src/core/features/google-analytics-instance-sharing.js
+++ b/src/core/features/google-analytics-instance-sharing.js
@@ -12,7 +12,7 @@ export const setupGoogleAnalyticsInstanceSharingFeature = (embedId) => {
 
   gaObject(function (tracker) {
     const gaClientId = tracker.get('clientId')
-    const message = { embedId, gaClientId }
-    window.postMessage({ type: 'ga-client-id', message }, '*')
+    const data = { embedId, gaClientId }
+    window.postMessage({ type: 'ga-client-id', data }, '*')
   })
 }

--- a/src/core/features/google-analytics-instance-sharing.js
+++ b/src/core/features/google-analytics-instance-sharing.js
@@ -13,6 +13,6 @@ export const setupGoogleAnalyticsInstanceSharingFeature = (embedId) => {
   gaObject(function (tracker) {
     const gaClientId = tracker.get('clientId')
     const message = { embedId, gaClientId }
-    window.postMessage('ga-client-id', message, '*')
+    window.postMessage({ type: 'ga-client-id', message }, '*')
   })
 }

--- a/src/core/make-popup.js
+++ b/src/core/make-popup.js
@@ -65,7 +65,8 @@ const queryStringKeys = {
   embedType: 'typeform-embed',
   hideFooter: 'embed-hide-footer',
   hideHeaders: 'embed-hide-headers',
-  disableTracking: 'disable-tracking'
+  disableTracking: 'disable-tracking',
+  shareGoogleAnalyticsInstance: 'share-ga-instance'
 }
 
 const renderComponent = (params, options) => {

--- a/src/core/make-popup.js
+++ b/src/core/make-popup.js
@@ -27,6 +27,7 @@ import Popup, {
 import MobileModal from './views/mobile-modal'
 import { getPostMessageHandler } from './utils/get-post-message-handler'
 import { handleAutoOpen } from './utils/popup-auto-open'
+import { setupGoogleAnalyticsInstanceSharingFeature } from './features/google-analytics-instance-sharing'
 
 const DEFAULT_DRAWER_WIDTH = 800
 const DEFAULT_POPUP_WIDTH = 320
@@ -49,6 +50,7 @@ const buildOptions = (embedId, options) => {
     hideScrollbars: false,
     disableTracking: false,
     transferableUrlParameters: options.transferableUrlParameters || [],
+    shareGoogleAnalyticsInstance: options.shareGoogleAnalyticsInstance || false,
     onSubmit: noop,
     open: null,
     openValue: null,
@@ -120,6 +122,10 @@ export default function makePopup (url, userOptions, element) {
   const embedId = randomString()
 
   const options = buildOptions(embedId, userOptions)
+
+  if (options.shareGoogleAnalyticsInstance) {
+    setupGoogleAnalyticsInstanceSharingFeature(embedId)
+  }
 
   if (!Number.isSafeInteger(options.width)) {
     throw new Error(

--- a/src/core/make-widget.js
+++ b/src/core/make-widget.js
@@ -65,6 +65,7 @@ export default function makeWidget (element, url, options) {
 
   render(
     <Widget
+      embedId={embedId}
       enabledFullscreen={enabledFullscreen}
       options={options}
       url={urlWithQueryString}

--- a/src/core/make-widget.js
+++ b/src/core/make-widget.js
@@ -15,6 +15,8 @@ import {
 } from './utils/mobile-detection'
 import Widget from './views/widget'
 import { getPostMessageHandler } from './utils/get-post-message-handler'
+import { setupGoogleAnalyticsInstanceSharingFeature } from './features/google-analytics-instance-sharing'
+import randomString from './utils/random-string'
 
 const defaultOptions = {
   mode: 'embed-widget',
@@ -37,7 +39,13 @@ const queryStringKeys = {
 export default function makeWidget (element, url, options) {
   options = { ...defaultOptions, ...options }
 
+  const embedId = randomString()
+
   window.addEventListener('message', getPostMessageHandler('form-ready', options.onReady))
+
+  if (options.shareGoogleAnalyticsInstance) {
+    setupGoogleAnalyticsInstanceSharingFeature(embedId)
+  }
 
   const enabledFullscreen = isMobile(navigator.userAgent)
 

--- a/src/core/make-widget.js
+++ b/src/core/make-widget.js
@@ -33,7 +33,8 @@ const queryStringKeys = {
   hideFooter: 'embed-hide-footer',
   hideHeaders: 'embed-hide-headers',
   opacity: 'embed-opacity',
-  disableTracking: 'disable-tracking'
+  disableTracking: 'disable-tracking',
+  shareGoogleAnalyticsInstance: 'share-ga-instance'
 }
 
 export default function makeWidget (element, url, options) {

--- a/src/core/views/popup.js
+++ b/src/core/views/popup.js
@@ -359,6 +359,7 @@ class Popup extends Component {
           />
         )}
         <Iframe
+          id={embedId}
           onLoad={this.handleIframeLoad}
           src={iframeUrl}
           style={iframeStyles}

--- a/src/core/views/widget.js
+++ b/src/core/views/widget.js
@@ -103,7 +103,7 @@ class Widget extends Component {
   constructor (props) {
     super(props)
 
-    this.embedId = randomString()
+    this.embedId = props.embedId
     this.mobileEmbedId = randomString()
     this.wrapperRef = createRef()
     this.fullScreenModalDiv = document.createElement('div')
@@ -269,6 +269,7 @@ class Widget extends Component {
           <Iframe
             frameBorder='0'
             height='100%'
+            id={this.embedId}
             ref={this.setIframeRef}
             src={inlineIframeUrl}
             width='100%'
@@ -309,7 +310,7 @@ Widget.propTypes = {
   url: PropTypes.string,
   options: PropTypes.object.isRequired,
   enabledFullscreen: PropTypes.bool,
-  embedId: PropTypes.string
+  embedId: PropTypes.string.isRequired
 }
 
 Widget.defaultProps = {

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -66,7 +66,7 @@ describe('Widget', () => {
         .mockImplementationOnce(() => MOBILE_EMBED_ID)
       const onSubmitMock = jest.fn()
       const options = { onSubmit: onSubmitMock }
-      mount(<Widget embedId={EMBED_ID} enabledFullscreen options={options} url={URL}/>)
+      mount(<Widget embedId={MOBILE_EMBED_ID} enabledFullscreen options={options} url={URL}/>)
 
       window.dispatchEvent(new CustomEvent('form-submit', { detail: { embedId: MOBILE_EMBED_ID } }))
       expect(onSubmitMock).toHaveBeenCalledTimes(1)

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -23,7 +23,7 @@ Enzyme.configure({ adapter: new Adapter() })
 
 describe('Widget', () => {
   it('renders an iframe with the passed url prop', () => {
-    const widget = shallow(<Widget url={URL} />)
+    const widget = shallow(<Widget embedId={EMBED_ID} url={URL} />)
 
     expect(widget.find(Iframe).prop('src')).toEqual(`${URL}?typeform-embed-id=${EMBED_ID}`)
   })
@@ -31,7 +31,7 @@ describe('Widget', () => {
   it('onSubmit callback is executed upon typeform submission when embed ID matches', () => {
     const onSubmitMock = jest.fn()
     const options = { onSubmit: onSubmitMock }
-    mount(<Widget options={options} url={URL} />)
+    mount(<Widget embedId={EMBED_ID} options={options} url={URL} />)
 
     window.dispatchEvent(new CustomEvent('form-submit', { detail: { embedId: EMBED_ID } }))
     expect(onSubmitMock).toHaveBeenCalledTimes(1)
@@ -40,7 +40,7 @@ describe('Widget', () => {
   it('onSubmit callback is not executed upon typeform submission when embed ID does not match', () => {
     const onSubmitMock = jest.fn()
     const options = { onSubmit: onSubmitMock }
-    mount(<Widget options={options} url={URL} />)
+    mount(<Widget embedId={EMBED_ID} options={options} url={URL} />)
 
     window.dispatchEvent(new CustomEvent('form-submit', { detail: { embedId: '098765' } }))
     expect(onSubmitMock).not.toHaveBeenCalled()
@@ -52,7 +52,7 @@ describe('Widget', () => {
     const getSubmitEventDataSpy = jest.spyOn(utils, 'getSubmitEventData')
     const event = new CustomEvent('form-submit', { detail: { embedId: EMBED_ID } })
 
-    shallow(<Widget options={options} url={URL} />)
+    shallow(<Widget embedId={EMBED_ID} options={options} url={URL} />)
 
     window.dispatchEvent(event)
     expect(getSubmitEventDataSpy).toHaveBeenCalledWith(event)
@@ -66,20 +66,20 @@ describe('Widget', () => {
         .mockImplementationOnce(() => MOBILE_EMBED_ID)
       const onSubmitMock = jest.fn()
       const options = { onSubmit: onSubmitMock }
-      mount(<Widget enabledFullscreen options={options} url={URL}/>)
+      mount(<Widget embedId={EMBED_ID} enabledFullscreen options={options} url={URL}/>)
 
       window.dispatchEvent(new CustomEvent('form-submit', { detail: { embedId: MOBILE_EMBED_ID } }))
       expect(onSubmitMock).toHaveBeenCalledTimes(1)
     })
 
     it('renders an iframe with disabled submissions', () => {
-      const wrapper = mount(<Widget enabledFullscreen url={URL}/>)
+      const wrapper = mount(<Widget embedId={EMBED_ID} enabledFullscreen url={URL}/>)
       expect(wrapper.find(Iframe)).toHaveLength(1)
       expect(wrapper.find(Iframe).props().src.includes('disable-tracking=true')).toBe(true)
     })
 
     it('renders a second iframe after the welcome-screen-hidden event', () => {
-      const wrapper = mount(<Widget enabledFullscreen url={URL}/>)
+      const wrapper = mount(<Widget embedId={EMBED_ID} enabledFullscreen url={URL}/>)
 
       let modal = wrapper.find(MobileModal)
       expect(wrapper.find(MobileModal).props().url.includes('typeform-welcome=0')).toBe(true)


### PR DESCRIPTION
# Motivation

Support the improvement to the Google Analytics Integration so that the Google analytics user session on the website where the Typeform is embedded is share to Typeform and even beyond and so that as the owner of the website I can get the accurate full view of the experience of the user and can get to improve it.

This specific feature is part of the bigger epic: https://jira.typeform.tf/browse/PI-88

# Under the hood

The changes allow you to specify a ```shareGoogleAnalyticsInstance```  option in the embed
and this had the effect to pass in a ```shareGoogleAnalyticsInstance``` parameter to the Typeform URL and to, if there is Google analytics in the page of the embed to pass a ```ga-client-id``` parameter via ```postMessage``` as soon as the google Analytics parameter Id is available.

# How to use the feature.


1) Enable the Google analytics integration

2) Enable the ```shareGoogleAnalyticsInstance``` in the embed:

In an HTML snippet using the embed:

```html
<div
      class="typeform-widget"
      data-url="mytypeformURL"
      data-share-google-analytics-instance
    ></div>
<script type="text/javascript" src="https://embed.typeform.com/embed.js"></script>
```

Using the API: 

```js

const embedElement = document.querySelector('.js-typeform-embed')

typeformEmbed.makeWidget(
  embedElement,
  'https://admin.typeform.com/to/PlBzgL',
  {
    buttonText: "Answer this!",
    shareGoogleAnalyticsInstance
  }
)
```

# JIRA: https://jira.typeform.tf/browse/PI-89

# Test plan

-  Unit tests to check that the embedded html snippet parse properly the `data-share-google-analytics-instance` parameter to the widget and popup api
- E2E test to chack that, when the ```shareGoogleAnalytics``` option is enabled, the ```share-ga-instance``` parameter is added to the Typeform URL and that the ```ga-client-id``` of the website google instance is transfered via ```postMessage``` to the Typeform.