### PR TITLE
fix(DIST-453): Fix page height calculation

### DIFF
--- a/demo/behavioral-api/scroll-api.html
+++ b/demo/behavioral-api/scroll-api.html
@@ -41,7 +41,8 @@
         const offsetTop = window.pageYOffset || document.documentElement.scrollTop
         const clientTop = document.documentElement.clientTop || 0
         const scrollTopPixels = offsetTop - clientTop
-        const scrollTopPercentage = scrollTopPixels / document.body.clientHeight * 100
+        const pageHeight = document.documentElement.scrollHeight
+        const scrollTopPercentage = scrollTopPixels / pageHeight * 100
         document.getElementById('scroll-pixels').innerHTML = scrollTopPixels;
         document.getElementById('scroll-percentage').innerHTML = (Math.round(scrollTopPercentage * 100) / 100).toFixed(2);
       })

--- a/demo/behavioral-code/scroll-code.html
+++ b/demo/behavioral-code/scroll-code.html
@@ -4,6 +4,19 @@
     <title>Open: scroll (via embed code)</title>
     <link rel="stylesheet" href="../demo.css" />
     <style>
+      html {
+        overflow-y: scroll;
+        overflow-x: hidden;
+        -webkit-overflow-scrolling: touch;
+        height: 100%;
+      }
+      body {
+        width: 100vw;
+        height: 100vh;
+        border-bottom: 10px rgba(0,0,0,0.25) solid;
+        margin: 20px;
+        padding: 20px;
+      }
       .scroll-indicator {
         position: fixed;
         top: 0;
@@ -59,7 +72,8 @@
         const offsetTop = window.pageYOffset || document.documentElement.scrollTop
         const clientTop = document.documentElement.clientTop || 0
         const scrollTopPixels = offsetTop - clientTop
-        const scrollTopPercentage = scrollTopPixels / document.documentElement.clientHeight * 100
+        const pageHeight = document.documentElement.scrollHeight
+        const scrollTopPercentage = scrollTopPixels / pageHeight * 100
         document.getElementById('scroll-pixels').innerHTML = scrollTopPixels;
         document.getElementById('scroll-percentage').innerHTML = (Math.round(scrollTopPercentage * 100) / 100).toFixed(2);
       })

--- a/src/core/utils/popup-auto-open.js
+++ b/src/core/utils/popup-auto-open.js
@@ -17,9 +17,10 @@ const openOnScroll = (popup, scrollThreshold) => {
   const handleScroll = () => {
     const offsetTop = window.pageYOffset || document.documentElement.scrollTop
     const clientTop = document.documentElement.clientTop || 0
+    const pageHeight = document.documentElement.scrollHeight
     const scrollTopPixels = offsetTop - clientTop
-    const scrollTopPercentage = scrollTopPixels / document.documentElement.clientHeight * 100
-    const scrolledToTheBottom = scrollTopPixels + window.innerHeight >= document.documentElement.clientHeight
+    const scrollTopPercentage = scrollTopPixels / pageHeight * 100
+    const scrolledToTheBottom = scrollTopPixels + window.innerHeight >= pageHeight
 
     if (scrollTopPercentage >= scrollThreshold || scrolledToTheBottom) {
       popup.open()

--- a/src/core/utils/popup-auto-open.spec.js
+++ b/src/core/utils/popup-auto-open.spec.js
@@ -89,7 +89,7 @@ describe('handleAutoOpen', () => {
     beforeAll(() => {
       global.document = {
         documentElement: {
-          clientHeight: 1000
+          scrollHeight: 1000
         },
         addEventListener: (_event, fn) => {
           handler = fn


### PR DESCRIPTION
There is an issue when host page has CSS.

```
html {
    overflow-y: scroll;
    overflow-x: hidden;
    height: 100%;
}
```

In that case we consider the page to have the same height as viewport, which is kind of correct (the <html> is 100%) but not really correct since page content overflows from <html>. See [DIST-453](https://jira.typeform.tf/browse/DIST-453) for details.

<!-- Thanks for submitting a PR! Please before merging this PR ensure all the following steps are fullfilled: -->

- [x] Explain the **motivation** for making this change.
- [x] Provide a solid **test plan** for your changes.
- [x]  Link to the issue - [DIST-453](https://jira.typeform.tf/browse/DIST-453)
