### PR TITLE
fix: Check embed ID in "onReady" and "onClose" callbacks

### DIFF
--- a/src/core/make-popup.js
+++ b/src/core/make-popup.js
@@ -5,6 +5,7 @@ import {
   appendParamsToUrl,
   replaceExistingKeys,
   ensureMetaViewport,
+  callIfEmbedIdMatches,
   noop
 } from './utils'
 import {
@@ -116,10 +117,10 @@ const renderComponent = (params, options) => {
 }
 
 export default function makePopup (url, userOptions, element) {
-  window.addEventListener('message', getPostMessageHandler('form-ready', userOptions.onReady))
-  window.addEventListener('message', getPostMessageHandler('form-closed', userOptions.onClose))
-
   const embedId = randomString()
+
+  window.addEventListener('message', callIfEmbedIdMatches(getPostMessageHandler('form-ready', userOptions.onReady), embedId))
+  window.addEventListener('message', callIfEmbedIdMatches(getPostMessageHandler('form-closed', userOptions.onClose), embedId))
 
   const options = buildOptions(embedId, userOptions)
 

--- a/src/core/make-widget.js
+++ b/src/core/make-widget.js
@@ -4,6 +4,7 @@ import { render } from 'react-dom'
 import {
   appendParamsToUrl,
   replaceExistingKeys,
+  callIfEmbedIdMatches,
   noop
 } from './utils'
 import {
@@ -14,6 +15,7 @@ import {
 } from './utils/mobile-detection'
 import Widget from './views/widget'
 import { getPostMessageHandler } from './utils/get-post-message-handler'
+import randomString from './utils/random-string'
 
 const defaultOptions = {
   mode: 'embed-widget',
@@ -34,9 +36,10 @@ const queryStringKeys = {
 }
 
 export default function makeWidget (element, url, options) {
+  const embedId = randomString()
   options = { ...defaultOptions, ...options }
 
-  window.addEventListener('message', getPostMessageHandler('form-ready', options.onReady))
+  window.addEventListener('message', callIfEmbedIdMatches(getPostMessageHandler('form-ready', options.onReady), embedId))
 
   const enabledFullscreen = isMobile(navigator.userAgent)
 
@@ -54,6 +57,7 @@ export default function makeWidget (element, url, options) {
 
   render(
     <Widget
+      embedId={embedId}
       enabledFullscreen={enabledFullscreen}
       options={options}
       url={urlWithQueryString}

--- a/src/core/make-widget.spec.js
+++ b/src/core/make-widget.spec.js
@@ -6,12 +6,16 @@ import makeWidget from './make-widget'
 import {
   isMobile as isMobileMock
 } from './utils/mobile-detection'
+import randomString from './utils/random-string'
 
 jest.mock('react-dom')
 jest.mock('./utils/mobile-detection')
+jest.mock('./utils/random-string')
 
 const URL = 'http://widget.cat'
-const UID = 'unique uid'
+const EMBED_ID = '123456'
+
+randomString.mockImplementation(() => EMBED_ID)
 
 describe('makeWidget', () => {
   it('renders a Widget component on desktop devices', () => {
@@ -64,9 +68,20 @@ describe('makeWidget', () => {
 
     makeWidget(element, URL, options)
 
-    window.postMessage({ type: 'form-ready' }, '*')
+    window.postMessage({ type: 'form-ready', embedId: EMBED_ID }, '*')
     await new Promise((resolve) => setTimeout(resolve))
     expect(options.onReady).toHaveBeenCalledTimes(1)
     expect(options.onReady).toHaveBeenCalledWith()
+  })
+
+  it(`onReady is not called for other embedId`, async () => {
+    const element = document.createElement('div')
+    const options = { onReady: jest.fn() }
+
+    makeWidget(element, URL, options)
+
+    window.postMessage({ type: 'form-ready', embedId: 'foo' }, '*')
+    await new Promise((resolve) => setTimeout(resolve))
+    expect(options.onReady).not.toHaveBeenCalled()
   })
 })

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -2,7 +2,10 @@ import UrlParse from 'url-parse'
 
 import onMessage from './message-propagation'
 
-export const checkEmbedId = (embedId, event) => event.detail && event.detail.embedId === embedId
+export const checkEmbedId = (embedId, event) => {
+  return (event.detail && event.detail.embedId === embedId) ||
+    (event.data && event.data.embedId === embedId)
+}
 
 export const callIfEmbedIdMatches = (func, embedId) => event => {
   if (checkEmbedId(embedId, event)) {

--- a/src/core/utils/index.spec.js
+++ b/src/core/utils/index.spec.js
@@ -95,11 +95,26 @@ describe('Utilities', () => {
   })
 
   describe('callIfEmbedIdMatches', () => {
-    test('returns a function that will execute callback if embedId matches', () => {
+    test('returns a function that will execute callback if details.embedId matches', () => {
       const embedId = '123456'
       const callback = jest.fn()
       const event = {
         detail: {
+          embedId
+        }
+      }
+
+      const func = utils.callIfEmbedIdMatches(callback, embedId)
+      func(event)
+
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    test('returns a function that will execute callback if data.embedId matches', () => {
+      const embedId = '123456'
+      const callback = jest.fn()
+      const event = {
+        data: {
           embedId
         }
       }

--- a/src/core/views/widget.js
+++ b/src/core/views/widget.js
@@ -104,7 +104,7 @@ class Widget extends Component {
   constructor (props) {
     super(props)
 
-    this.embedId = randomString()
+    this.embedId = props.embedId || randomString()
     this.mobileEmbedId = randomString()
     this.wrapperRef = createRef()
     this.fullScreenModalDiv = document.createElement('div')

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -14,7 +14,6 @@ import Iframe from './components/iframe'
 jest.mock('../utils/random-string')
 
 const URL = 'http://widget.cat'
-const UID = 'a unique id'
 const EMBED_ID = '123456'
 
 randomString.mockImplementation(() => EMBED_ID)


### PR DESCRIPTION
When there are multiple forms on page the callbacks are triggered from other forms too.