### PR TITLE
chore(DIST-589): Update release Github Action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GH_TOKEN_SEMANTIC_RELEASE: ${{ secrets.GH_TOKEN_SEMANTIC_RELEASE }}
   AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
   AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
   AWS_ASSETS_BUCKET: 'typeform-public-assets/embed'
@@ -27,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install
       - run: yarn build
-      - run: yarn semantic-release
+      - run: GH_TOKEN=$GH_TOKEN_SEMANTIC_RELEASE yarn semantic-release
   release_aws:
     name: Release to AWS
     runs-on: ubuntu-latest # [self-hosted, node-12]


### PR DESCRIPTION
Use admin account Github token with write permissions for semantic release to push commit with changelog and bumped version in pacakge.json.