### PR TITLE
feat: Use form ID instead of whole URL

### DIFF
--- a/packages/embed-kitchen-sink/stories/Popup.stories.js
+++ b/packages/embed-kitchen-sink/stories/Popup.stories.js
@@ -3,16 +3,16 @@ import { createPopup } from "@typeform/embed/src";
 export default {
   title: "Embed/Popup",
   argTypes: {
-    typeformUrl: {
-      name: "Typeform URL",
+    typeformId: {
+      name: "Typeform ID",
       control: "text",
-      defaultValue: "https://form.typeform.com/to/moe6aa",
+      defaultValue: "moe6aa",
     },
   },
 };
 
-const Template = ({ typeformUrl }) => {
-  const { open, close } = createPopup(typeformUrl, {});
+const Template = ({ typeformId }) => {
+  const { open, close } = createPopup(typeformId, {});
 
   const button = document.createElement("button");
   button.innerText = "Toggle popup";

--- a/packages/embed-kitchen-sink/stories/Widget.stories.js
+++ b/packages/embed-kitchen-sink/stories/Widget.stories.js
@@ -3,17 +3,17 @@ import { createWidget } from "@typeform/embed/src";
 export default {
   title: "Embed/Widget",
   argTypes: {
-    typeformUrl: {
+    typeformId: {
       name: "Typeform URL",
       control: "text",
-      defaultValue: "https://form.typeform.com/to/moe6aa",
+      defaultValue: "moe6aa",
     },
   },
 };
 
-const Template = ({ typeformUrl }) => {
+const Template = ({ typeformId }) => {
   const container = document.createElement("div");
-  createWidget(typeformUrl, { container });
+  createWidget(typeformId, { container });
   return container;
 };
 

--- a/packages/embed-kitchen-sink/stories/Window.stories.js
+++ b/packages/embed-kitchen-sink/stories/Window.stories.js
@@ -1,20 +1,20 @@
 export default {
   title: "Embed/Window",
   argTypes: {
-    typeformUrl: {
+    typeformId: {
       name: "Typeform URL",
       control: "text",
-      defaultValue: "https://form.typeform.com/to/moe6aa",
+      defaultValue: "moe6aa",
     },
   },
 };
 
-const Template = ({ typeformUrl }) => {
+const Template = ({ typeformId }) => {
   return `
     <div id="wrapper"></div>
     <script src="/embed-next.js"></script>
     <script>
-      window.tf.createWidget("${typeformUrl}", { container: document.querySelector("#wrapper")})
+      window.tf.createWidget("${typeformId}", { container: document.querySelector("#wrapper")})
     </script>
   `;
 };

--- a/packages/embed/.eslintrc.js
+++ b/packages/embed/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@typeform/eslint-config', 'prettier', 'prettier/react', 'plugin:prettier/recommended'],
+  rules: {
+    'no-restricted-imports': ['error', { patterns: ['./../*'] }], // do not use unnecessary leading `./`
+  },
 }

--- a/packages/embed/src/factories/create-popup/create-popup.ts
+++ b/packages/embed/src/factories/create-popup/create-popup.ts
@@ -9,8 +9,8 @@ export type Popup = {
   refresh: () => void
 }
 
-export const createPopup = (formUrl: string, options: PopupOptions): Popup => {
-  const iframe = createIframe(formUrl, 'popup', options)
+export const createPopup = (formId: string, options: PopupOptions): Popup => {
+  const iframe = createIframe(formId, 'popup', options)
   const popup = buildPopup(iframe)
   const container = options.container || document.body
 

--- a/packages/embed/src/utils/build-iframe-src.ts
+++ b/packages/embed/src/utils/build-iframe-src.ts
@@ -1,5 +1,5 @@
 import { EmbedType, UrlOptions } from '../base'
 
-export const buildIframeSrc = (formUrl: string, _type: EmbedType, _options: UrlOptions) => {
-  return formUrl
+export const buildIframeSrc = (formId: string, _type: EmbedType, _options: UrlOptions) => {
+  return `https://form.typeform.com/to/${formId}`
 }

--- a/packages/embed/src/utils/build-iframe.src.spec.ts
+++ b/packages/embed/src/utils/build-iframe.src.spec.ts
@@ -3,7 +3,7 @@ import { buildIframeSrc } from './build-iframe-src'
 describe('build-iframe-src', () => {
   describe('#buildIframeSrc', () => {
     it('should return iframe src', () => {
-      expect(buildIframeSrc('some-url', 'widget', {})).toBe('some-url')
+      expect(buildIframeSrc('some-id', 'widget', {})).toBe('https://form.typeform.com/to/some-id')
     })
   })
 })

--- a/packages/embed/src/utils/create-iframe/create-iframe.spec.ts
+++ b/packages/embed/src/utils/create-iframe/create-iframe.spec.ts
@@ -13,11 +13,11 @@ describe('create-iframe', () => {
     const options = {}
 
     beforeEach(() => {
-      iframe = createIframe('url', 'fullpage', options)
+      iframe = createIframe('form-id', 'fullpage', options)
     })
 
     it('should call buildIframeSrc', () => {
-      expect(buildIframeSrcMock).toHaveBeenCalledWith('url', 'fullpage', options)
+      expect(buildIframeSrcMock).toHaveBeenCalledWith('form-id', 'fullpage', options)
     })
 
     it('should create new iframe element', () => {

--- a/packages/embed/src/utils/create-iframe/create-iframe.ts
+++ b/packages/embed/src/utils/create-iframe/create-iframe.ts
@@ -1,10 +1,10 @@
 import { EmbedType, UrlOptions } from '../../base'
+import { buildIframeSrc } from '../build-iframe-src'
 
-import { buildIframeSrc } from './../build-iframe-src'
 import { triggerIframeRedraw } from './trigger-iframe-redraw'
 
-export const createIframe = (formUrl: string, type: EmbedType, options: UrlOptions) => {
-  const src = buildIframeSrc(formUrl, type, options)
+export const createIframe = (formId: string, type: EmbedType, options: UrlOptions) => {
+  const src = buildIframeSrc(formId, type, options)
 
   const iframe = document.createElement('iframe')
   iframe.src = src


### PR DESCRIPTION
We dont need whole URL, since we recommend "form" subdomain to avoid possible issues
when subdomain is changed. Standard subdomain "form" will always work.