### PR TITLE
feat(DIST-707): Remove full page type

### DIFF
--- a/packages/embed/src/base/embed-types.ts
+++ b/packages/embed/src/base/embed-types.ts
@@ -1,1 +1,1 @@
-export type EmbedType = 'fullpage' | 'widget' | 'popup' | 'drawer_left' | 'drawer_right' | 'popover' | 'side_panel'
+export type EmbedType = 'widget' | 'popup' | 'slider' | 'popover' | 'side-tab'

--- a/packages/embed/src/factories/create-widget/create-widget.ts
+++ b/packages/embed/src/factories/create-widget/create-widget.ts
@@ -11,8 +11,7 @@ export const createWidget = (formId: string, options: WidgetOptions): Widget => 
   const iframe = createIframe(formId, 'widget', options)
   const widget = buildWidget(iframe)
 
-  const container = options.container || document.body
-  container.append(widget)
+  options.container.append(widget)
 
   return {
     refresh: () => iframe.contentWindow?.location.reload(),

--- a/packages/embed/src/factories/create-widget/widget-options.ts
+++ b/packages/embed/src/factories/create-widget/widget-options.ts
@@ -2,5 +2,5 @@ import { ActionableOptions, UrlOptions } from '../../base'
 
 export type WidgetOptions = UrlOptions &
   ActionableOptions & {
-    container?: HTMLElement
+    container: HTMLElement
   }

--- a/packages/embed/src/utils/create-iframe/create-iframe.spec.ts
+++ b/packages/embed/src/utils/create-iframe/create-iframe.spec.ts
@@ -13,11 +13,11 @@ describe('create-iframe', () => {
     const options = {}
 
     beforeEach(() => {
-      iframe = createIframe('form-id', 'fullpage', options)
+      iframe = createIframe('form-id', 'widget', options)
     })
 
     it('should call buildIframeSrc', () => {
-      expect(buildIframeSrcMock).toHaveBeenCalledWith('form-id', 'fullpage', options)
+      expect(buildIframeSrcMock).toHaveBeenCalledWith('form-id', 'widget', options)
     })
 
     it('should create new iframe element', () => {


### PR DESCRIPTION
Same functionality can be achieved by a widget in full screen container.
We can add shorthand once widget is fully implemented, if necessary.

Also, adding widgets to end of body does not really make sense. It breaks single page apps (body is never reloaded) and on script reload it adds multiple forms.