### PR TITLE
chore(DIST-690): Add master as branch in release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,7 @@
 {
   "branches": [
-    { name: 'next', prerelease: true }
+    "master",
+    { name: "next", prerelease: true }
   ],
   extends: [
     "semantic-release-monorepo"


### PR DESCRIPTION
## Description

Semantic Release throws an error due to the lack of a main branch in release config, this adds master as main branch and keeps next as a prerelease tag

## Checklist

<!-- Thanks for submitting a PR! Please before merging this PR ensure all the following steps are fullfilled: -->

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a solid **test plan** for your changes.
- [ ] Link to the issue - if any [issue number here]()
