### PR TITLE
chore: Switch to node 10, test for 10, 12, 14 and 15

### DIFF
--- a/.github/workflows/pull-request-next.yml
+++ b/.github/workflows/pull-request-next.yml
@@ -16,17 +16,25 @@ env:
 jobs:
   build-lint-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version:
+          - 10 # end of life 2021-04-30
+          - 12 # end of life 2022-04-30
+          - 14 # end of life 2023-04-30
+          - 15 # current
+    name: build-lint-test - node ${{ matrix.node_version }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: ${{ matrix.node_version }}
       - uses: actions/cache@v2
         with:
           path: |
             **/node_modules
             ~/.cache
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-${{ matrix.node_version }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install  --frozen-lockfile
       - run: yarn lerna run build
       - run: yarn lerna run lint
@@ -42,8 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-        with:
-          node-version: "14"
       - uses: actions/cache@v2
         with:
           path: |
@@ -58,8 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-        with:
-          node-version: "14"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.GH_TOKEN }}
       - uses: actions/setup-node@v1
-        with:
-          node-version: "14"
       - uses: actions/cache@v2
         with:
           path: |
@@ -70,8 +68,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-        with:
-          node-version: "14"
       - uses: actions/cache@v2
         with:
           path: |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=14"
+    "node": ">=10"
   },
   "workspaces": [
     "packages/*"

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -6,7 +6,7 @@
   "author": "Typeform",
   "license": "LGPL-3.0-only",
   "engines": {
-    "node": ">=14"
+    "node": ">=10"
   },
   "dependencies": {
     "@typeform/embed": "file:../embed"

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -6,7 +6,7 @@ Core library written in Typescript. Compiles to vanilla JavaScript.
 
 Requirements:
 
-- node >= 14
+- node >= 10
 - yarn
 
 Install dependencies

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -5,7 +5,7 @@
   "author": "Typeform",
   "license": "LGPL-3.0-only",
   "engines": {
-    "node": ">=14"
+    "node": ">=10"
   },
   "scripts": {
     "clean": "rm -rf ./build",


### PR DESCRIPTION
While it is nice to develop a project on latest node, when we develop a library we should consider not all consumers will be using latest node. 

Lets try to support Node >=10+ as per https://nodejs.org/en/about/releases/
```
          - 10 # end of life 2021-04-30
          - 12 # end of life 2022-04-30
          - 14 # end of life 2023-04-30
          - 15 # current
```

We should test for each node version and remove them as their end of life date passes.

For example [CodeSandbox still uses Node 10 as default](https://codesandbox.io/docs/faq#can-i-change-the-node-version-used-in-a-container-sandbox).

![Screenshot 2021-02-26 at 09 58 31](https://user-images.githubusercontent.com/1561771/109278800-3e51dd00-7819-11eb-8331-bdd15a44ac8c.png)
