### PR TITLE
feat: Add support for hidden fields

### DIFF
--- a/packages/demo-html/public/popup-html.html
+++ b/packages/demo-html/public/popup-html.html
@@ -6,7 +6,9 @@
     <link rel="stylesheet" href="./lib/css/popup.css" />
   </head>
   <body>
-    <button id="button" data-tf-popup="moe6aa" data-tf-medium="demo-test">toggle default (large)</button>
+    <button id="button" data-tf-popup="moe6aa" data-tf-medium="demo-test" data-tf-hidden="foo=foo value,bar=bar value">
+      toggle default (large)
+    </button>
     <button data-tf-popup="moe6aa" data-tf-medium="demo-test" data-tf-size="80">toggle medium</button>
     <button data-tf-popup="moe6aa" data-tf-medium="demo-test" data-tf-size="45">toggle small</button>
     <button data-tf-popup="moe6aa" data-tf-medium="demo-test" data-tf-width="380" data-tf-height="300">

--- a/packages/demo-html/public/popup-js.html
+++ b/packages/demo-html/public/popup-js.html
@@ -9,10 +9,12 @@
     <button id="button">toggle</button>
     <script src="./lib/embed-next.js"></script>
     <script>
-      const { open, close } = window.tf.createPopup("moe6aa", { medium: "demo-test" });
+      const { toggle } = window.tf.createPopup("moe6aa", {
+        medium: "demo-test",
+        hidden: { foo: "foo value", bar: "bar value" },
+      });
       document.getElementById("button").onclick = function () {
-        const isOpen = !!document.querySelector(".typeform-popup");
-        isOpen ? close() : open();
+        toggle();
       };
     </script>
   </body>

--- a/packages/demo-html/public/slider-js.html
+++ b/packages/demo-html/public/slider-js.html
@@ -19,14 +19,12 @@
     <script>
       const sliderRight = window.tf.createSlider("moe6aa", { medium: "demo-test" });
       document.getElementById("button").onclick = function () {
-        const isOpen = !!document.querySelector(".typeform-slider");
-        isOpen ? sliderRight.close() : sliderRight.open();
+        sliderRight.toggle();
       };
 
       const sliderleft = window.tf.createSlider("moe6aa", { medium: "demo-test" });
       document.getElementById("button-left").onclick = function () {
-        const isOpen = !!document.querySelector(".typeform-slider");
-        isOpen ? sliderleft.close() : sliderleft.open();
+        sliderleft.toggle();
       };
     </script>
   </body>

--- a/packages/demo-html/public/widget-html.html
+++ b/packages/demo-html/public/widget-html.html
@@ -14,9 +14,11 @@
   <body>
     <div
       id="wrapper"
-      data-tf-widget="moe6aa"
+      data-tf-widget="jAJ5qj"
       data-tf-medium="demo-test"
       data-tf-transitive-search-params="foo,bar"
+      data-tf-hidden="foo=foo value,bar=bar value"
+      data-tf-opacity="50"
     ></div>
     <script src="./lib/embed-next.js"></script>
   </body>

--- a/packages/demo-html/public/widget-js.html
+++ b/packages/demo-html/public/widget-js.html
@@ -20,6 +20,7 @@
         container: document.getElementById("wrapper"),
         transitiveSearchParams: ["foo", "bar"],
         medium: "demo-test",
+        hidden: { foo: "foo value", bar: "bar value" },
       });
     </script>
   </body>

--- a/packages/demo-nextjs/pages/index.js
+++ b/packages/demo-nextjs/pages/index.js
@@ -17,6 +17,7 @@ export default function Home() {
       container: container.current,
       medium: "demo-test",
       transitiveSearchParams: ["foo", "bar"],
+      hidden: { foo: "foo value", bar: "bar value" },
     });
   }, [container.current]);
 

--- a/packages/demo-nextjs/pages/popup.js
+++ b/packages/demo-nextjs/pages/popup.js
@@ -3,7 +3,7 @@ import { createPopup, createSlider } from "@typeform/embed";
 
 export default function Popup() {
   const openPopup = () => {
-    createPopup("moe6aa", { medium: "demo-test" }).open();
+    createPopup("moe6aa", { medium: "demo-test", hidden: { foo: "foo value", bar: "bar value" } }).open();
   };
 
   return (

--- a/packages/embed/e2e/spec/functional/popup.spec.ts
+++ b/packages/embed/e2e/spec/functional/popup.spec.ts
@@ -26,6 +26,10 @@ function testPopup(path: string, title: string) {
         .should('contain', 'typeform-embed=popup-blank&typeform-source=localhost&typeform-medium=demo-test')
     })
 
+    it('should pass hidden fields as hash', () => {
+      cy.get('.typeform-popup iframe').invoke('attr', 'src').should('contain', '#foo=foo+value&bar=bar+value')
+    })
+
     it('should close popup', () => {
       cy.get('a.typeform-close').click()
       cy.get('.typeform-popup').should('not.exist')

--- a/packages/embed/e2e/spec/functional/widget.spec.ts
+++ b/packages/embed/e2e/spec/functional/widget.spec.ts
@@ -18,7 +18,11 @@ function testWidget(path: string, title: string) {
     it('should pass options as query param', () => {
       cy.get('.typeform-widget iframe')
         .invoke('attr', 'src')
-        .should('contain', 'typeform-embed=embed-widget&typeform-source=localhost&typeform-medium=demo' + '-test')
+        .should('contain', 'typeform-embed=embed-widget&typeform-source=localhost&typeform-medium=demo-test')
+    })
+
+    it('should pass hidden fields as hash', () => {
+      cy.get('.typeform-widget iframe').invoke('attr', 'src').should('contain', '#foo=foo+value&bar=bar+value')
     })
 
     it('should pass params from options to the iframe', () => {

--- a/packages/embed/src/base/base-options.ts
+++ b/packages/embed/src/base/base-options.ts
@@ -1,0 +1,8 @@
+export type BaseOptions = {
+  /**
+   * List of hidden fields
+   *
+   * @type {Record<string,string>}
+   */
+  hidden?: Record<string, string>
+}

--- a/packages/embed/src/base/index.ts
+++ b/packages/embed/src/base/index.ts
@@ -1,4 +1,5 @@
 export * from './embed-types'
+export * from './base-options'
 export * from './url-options'
 export * from './actionable-options'
 export * from './behavioral-type'

--- a/packages/embed/src/constants.ts
+++ b/packages/embed/src/constants.ts
@@ -6,3 +6,4 @@ export const SIDETAB_ATTRIBUTE = 'data-tf-sidetab'
 export const SLIDER_POSITION = 'right'
 export const SLIDER_WIDTH = 800
 export const POPUP_SIZE = 100
+export const FORM_BASE_URL = 'https://form.typeform.com'

--- a/packages/embed/src/css/popover.scss
+++ b/packages/embed/src/css/popover.scss
@@ -21,7 +21,7 @@
     opacity: 0;
     transition: opacity 0.25s ease-in-out;
     border-radius: 4px;
-    box-shadow: rgba(0, 0, 0, 0.08) 0px 2px 4px, rgba(0, 0, 0, 0.06) 0px 2px 12px;
+    box-shadow: rgba(0, 0, 0, 0.08) 0 2px 4px, rgba(0, 0, 0, 0.06) 0 2px 12px;
 
     iframe {
       @include iframe;
@@ -33,7 +33,7 @@
     width: 54px;
     height: 54px;
     position: fixed;
-    box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.06), 0px 2px 4px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06), 0 2px 4px rgba(0, 0, 0, 0.08);
     color: white;
     right: 26px;
     bottom: 26px;

--- a/packages/embed/src/css/popup.scss
+++ b/packages/embed/src/css/popup.scss
@@ -10,6 +10,7 @@
   height: 100%;
   background: rgba(0, 0, 0, 0.75);
   transition: opacity 0.25s ease-in-out;
+  z-index: 10001;
 
   .typeform-iframe-wrapper {
     position: absolute;
@@ -28,7 +29,7 @@
     @include close;
 
     top: -34px;
-    right: 0px;
+    right: 0;
   }
 
   .typeform-spinner {

--- a/packages/embed/src/css/sidetab.scss
+++ b/packages/embed/src/css/sidetab.scss
@@ -1,4 +1,5 @@
 @import 'includes/spinner';
+@import 'includes/iframe';
 
 .typeform-sidetab {
   position: fixed;
@@ -10,11 +11,11 @@
   transition: transform 250ms ease-in-out;
   will-change: transform;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08), 0 2px 12px rgba(0, 0, 0, 0.06);
+  z-index: 10001;
 
   iframe {
-    width: 100%;
-    height: 100%;
-    border: none;
+    @include iframe;
+    border-radius: 8px 0 0 8px;
   }
 
   &.open {
@@ -35,7 +36,7 @@
     display: flex;
     align-items: center;
     padding: 0 16px;
-    border-radius: 4px 4px 0px 0px;
+    border-radius: 8px 8px 0 0;
     color: white;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08), 0 2px 12px rgba(0, 0, 0, 0.06);
     background-color: #3a7685;

--- a/packages/embed/src/css/slider.scss
+++ b/packages/embed/src/css/slider.scss
@@ -10,6 +10,7 @@
   height: 100%;
   background: rgba(0, 0, 0, 0.75);
   transition: opacity 0.25s ease-in-out;
+  z-index: 10001;
 
   .typeform-iframe-wrapper {
     height: 100%;

--- a/packages/embed/src/factories/create-popover/popover-options.ts
+++ b/packages/embed/src/factories/create-popover/popover-options.ts
@@ -1,6 +1,7 @@
-import { ActionableOptions, UrlOptions, BehavioralOptions } from '../../base'
+import { ActionableOptions, BaseOptions, UrlOptions, BehavioralOptions } from '../../base'
 
-export type PopoverOptions = UrlOptions &
+export type PopoverOptions = BaseOptions &
+  UrlOptions &
   ActionableOptions &
   BehavioralOptions & {
     /**

--- a/packages/embed/src/factories/create-popup/popup-options.ts
+++ b/packages/embed/src/factories/create-popup/popup-options.ts
@@ -1,6 +1,7 @@
-import { ActionableOptions, UrlOptions, BehavioralOptions } from '../../base'
+import { ActionableOptions, BaseOptions, UrlOptions, BehavioralOptions } from '../../base'
 
-export type PopupOptions = UrlOptions &
+export type PopupOptions = BaseOptions &
+  UrlOptions &
   ActionableOptions &
   BehavioralOptions & {
     /**

--- a/packages/embed/src/factories/create-sidetab/create-sidetab.ts
+++ b/packages/embed/src/factories/create-sidetab/create-sidetab.ts
@@ -60,9 +60,9 @@ const buildTriggerButtonText = (text: string) => {
 
 const buildIcon = (customIcon?: string) => {
   const triggerIcon = document.createElement('div')
-  triggerIcon.className = 'typeform-popover-button-icon'
+  triggerIcon.className = 'typeform-sidetab-button-icon'
   triggerIcon.innerHTML = customIcon
-    ? `<img alt='popover trigger icon button' src='${customIcon}'/>`
+    ? `<img alt='sidetab trigger icon button' src='${customIcon}'/>`
     : `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path d="M21 0H0V9L10.5743 24V16.5H21C22.6567 16.5 24 15.1567 24 13.5V3C24 1.34325 22.6567 0 21 0ZM7.5 9.75C6.672 9.75 6 9.07875 6 8.25C6 7.42125 6.672 6.75 7.5 6.75C8.328 6.75 9 7.42125 9 8.25C9 9.07875 8.328 9.75 7.5 9.75ZM12.75 9.75C11.922 9.75 11.25 9.07875 11.25 8.25C11.25 7.42125 11.922 6.75 12.75 6.75C13.578 6.75 14.25 7.42125 14.25 8.25C14.25 9.07875 13.578 9.75 12.75 9.75ZM18 9.75C17.172 9.75 16.5 9.07875 16.5 8.25C16.5 7.42125 17.172 6.75 18 6.75C18.828 6.75 19.5 7.42125 19.5 8.25C19.5 9.07875 18.828 9.75 18 9.75Z" fill="white"></path>
 </svg>`

--- a/packages/embed/src/factories/create-sidetab/sidetab-options.ts
+++ b/packages/embed/src/factories/create-sidetab/sidetab-options.ts
@@ -1,6 +1,7 @@
-import { ActionableOptions, UrlOptions, BehavioralOptions } from '../../base'
+import { ActionableOptions, BaseOptions, UrlOptions, BehavioralOptions } from '../../base'
 
-export type SidetabOptions = UrlOptions &
+export type SidetabOptions = BaseOptions &
+  UrlOptions &
   ActionableOptions &
   BehavioralOptions & {
     /**

--- a/packages/embed/src/factories/create-slider/slider-options.ts
+++ b/packages/embed/src/factories/create-slider/slider-options.ts
@@ -1,6 +1,7 @@
-import { ActionableOptions, UrlOptions, BehavioralOptions } from '../../base'
+import { ActionableOptions, BaseOptions, UrlOptions, BehavioralOptions } from '../../base'
 
-export type SliderOptions = UrlOptions &
+export type SliderOptions = BaseOptions &
+  UrlOptions &
   ActionableOptions &
   BehavioralOptions & {
     /**

--- a/packages/embed/src/factories/create-widget/widget-options.ts
+++ b/packages/embed/src/factories/create-widget/widget-options.ts
@@ -1,6 +1,7 @@
-import { ActionableOptions, UrlOptions } from '../../base'
+import { ActionableOptions, BaseOptions, UrlOptions } from '../../base'
 
-export type WidgetOptions = UrlOptions &
+export type WidgetOptions = BaseOptions &
+  UrlOptions &
   ActionableOptions & {
     container: HTMLElement
   }

--- a/packages/embed/src/initializers/build-options-from-attributes.spec.ts
+++ b/packages/embed/src/initializers/build-options-from-attributes.spec.ts
@@ -17,6 +17,7 @@ describe('build-options-from-attributes', () => {
         data-tf-on-question-changed="onTypeformQuestionChanged"
         data-tf-open="exit"
         data-tf-open-value="3000"
+        data-tf-hidden="foo=foo value,bar=some bar value"
       ></div>`
 
     it('should load correct options', () => {
@@ -43,6 +44,7 @@ describe('build-options-from-attributes', () => {
         onSubmit: 'function',
         onQuestionChanged: 'function',
         transitiveSearchParams: 'array',
+        hidden: 'record',
       })
       expect(options).toEqual({
         source: 'unit-test-source',
@@ -57,6 +59,10 @@ describe('build-options-from-attributes', () => {
         onQuestionChanged: win.onTypeformQuestionChanged,
         open: 'exit',
         openValue: 3000,
+        hidden: {
+          foo: 'foo value',
+          bar: 'some bar value',
+        },
       })
     })
   })

--- a/packages/embed/src/initializers/build-options-from-attributes.ts
+++ b/packages/embed/src/initializers/build-options-from-attributes.ts
@@ -18,6 +18,7 @@ export const buildOptionsFromAttributes = (
     onSubmit: 'function',
     onQuestionChanged: 'function',
     transitiveSearchParams: 'array',
+    hidden: 'record',
     ...additionalAttributes,
   })
 }

--- a/packages/embed/src/utils/build-iframe-src.ts
+++ b/packages/embed/src/utils/build-iframe-src.ts
@@ -1,4 +1,5 @@
-import { EmbedType, UrlOptions } from '../base'
+import { BaseOptions, EmbedType, UrlOptions } from '../base'
+import { FORM_BASE_URL } from '../constants'
 
 import { removeUndefinedKeys } from './remove-undefined-keys'
 import { isDefined } from './is-defined'
@@ -43,13 +44,27 @@ export const buildIframeSrc = (params: BuildIframeSrcOptions): string => {
   const { formId, type, embedId, options } = params
   const queryParams = mapOptionsToQueryParams(type, embedId, addDefaultUrlOptions(options))
 
-  const url = new URL(`https://form.typeform.com/to/${formId}`)
+  const url = new URL(`${FORM_BASE_URL}/to/${formId}`)
 
   Object.entries(queryParams)
     .filter(([, paramValue]) => isDefined(paramValue))
     .forEach(([paramName, paramValue]) => {
       url.searchParams.set(paramName, paramValue)
     })
+
+  if (options.hidden) {
+    const tmpHashUrl = new URL(FORM_BASE_URL)
+    Object.entries(options.hidden)
+      .filter(([, paramValue]) => isDefined(paramValue))
+      .forEach(([paramName, paramValue]) => {
+        tmpHashUrl.searchParams.set(paramName, paramValue)
+      })
+    const hiddenFields = tmpHashUrl.searchParams.toString()
+    if (hiddenFields) {
+      url.hash = hiddenFields
+    }
+  }
+
   return url.href
 }
 
@@ -57,5 +72,5 @@ type BuildIframeSrcOptions = {
   formId: string
   embedId: string
   type: EmbedType
-  options: UrlOptions
+  options: BaseOptions & UrlOptions
 }

--- a/packages/embed/src/utils/build-iframe.src.spec.ts
+++ b/packages/embed/src/utils/build-iframe.src.spec.ts
@@ -51,6 +51,10 @@ describe('build-iframe-src', () => {
         opacity: 50,
         disableTracking: true,
         disableAutoFocus: true,
+        hidden: {
+          foo: 'foo value',
+          bar: '@bar&value?',
+        },
       }
       expect(buildIframeSrc({ formId: 'some-id', type: 'widget', embedId: 'embed-id', options })).toBe(
         'https://form.typeform.com/to/some-id' +
@@ -63,7 +67,8 @@ describe('build-iframe-src', () => {
           '&embed-hide-headers=true' +
           '&embed-opacity=50' +
           '&disable-tracking=true' +
-          '&disable-auto-focus=true'
+          '&disable-auto-focus=true' +
+          '#foo=foo+value&bar=%40bar%26value%3F'
       )
     })
   })

--- a/packages/embed/src/utils/load-options-from-attributes.spec.ts
+++ b/packages/embed/src/utils/load-options-from-attributes.spec.ts
@@ -100,6 +100,28 @@ describe('load-options-from-attributes', () => {
     })
   })
 
+  describe('to record (object)', () => {
+    it('should transform string as record', () => {
+      expect(transformAttributeValue('a=aa, b=bb', 'record')).toEqual({ a: 'aa', b: 'bb' })
+    })
+
+    it('should remove empty spaces in values, not around keys', () => {
+      expect(transformAttributeValue('foo key=foo value , bar =bar value , test key = test=value ', 'record')).toEqual({
+        'foo key': 'foo value ',
+        bar: 'bar value ',
+        'test key': ' test=value ',
+      })
+    })
+
+    it('should transform malformed string in empty record', () => {
+      expect(transformAttributeValue(',', 'record')).toEqual({})
+    })
+
+    it('should return undefined if no value', () => {
+      expect(transformAttributeValue('', 'record')).toEqual(undefined)
+    })
+  })
+
   describe('#loadOptionsFromAttributes', () => {
     const wrapper = document.createElement('div')
     wrapper.innerHTML = `<div id="element"

--- a/packages/embed/src/utils/load-options-from-attributes.ts
+++ b/packages/embed/src/utils/load-options-from-attributes.ts
@@ -10,7 +10,7 @@ export const camelCaseToKebabCase = (value: string) => {
     .join('')
 }
 
-export type Transformation = 'string' | 'boolean' | 'integer' | 'function' | 'array'
+export type Transformation = 'string' | 'boolean' | 'integer' | 'function' | 'array' | 'record'
 
 const transformString = (value: string | null): string | undefined => {
   return value || undefined
@@ -31,11 +31,28 @@ const transformFunction = (value: string | null): Function | undefined => {
 }
 
 const transformArray = (value: string | null): string[] | undefined => {
-  const val = value
+  if (!value) {
+    return undefined
+  }
+  return value
     ?.replace(/\s/g, '')
     .split(',')
     .filter((v) => !!v)
-  return value ? val : undefined
+}
+
+const transformRecord = (value: string | null): Record<string, string> | undefined => {
+  if (!value) {
+    return undefined
+  }
+  const arrayOfRecordStrings = value.split(',').filter((v) => !!v)
+  return arrayOfRecordStrings.reduce((record, recordString) => {
+    const match = recordString.match(/^([^=]+)=(.*)$/)
+    if (match) {
+      const [, key, value] = match
+      return { ...record, [key.trim()]: value }
+    }
+    return record
+  }, {})
 }
 
 export const transformAttributeValue = (value: string | null, transformation: Transformation) => {
@@ -50,6 +67,8 @@ export const transformAttributeValue = (value: string | null, transformation: Tr
       return transformFunction(value)
     case 'array':
       return transformArray(value)
+    case 'record':
+      return transformRecord(value)
     default:
       throw new Error(`Invalid attribute transformation ${transformation}`)
   }


### PR DESCRIPTION
While writing docs I noticed we dont support hidden fields since we dont pass form URL but rather just its ID. 

Benefits of this approach is we take care of encoding hidden fields values and therefore users dont need to encode it themselves, eg. this is totally valid: `data-tf-hidden="name=John X. Doe,hobbies=music&sport,age=???"`.