### PR TITLE
fix(DIST-864): Calculate mobile modal height for popup

### DIFF
--- a/src/core/views/mobile-modal.js
+++ b/src/core/views/mobile-modal.js
@@ -26,7 +26,7 @@ const Wrapper = styled.div`
   z-index: 10001;
   left: 0 !important;
   right: 0 !important;
-  top: 80px !important;
+  top: 0 !important;
   bottom: 0 !important;
   overflow: hidden !important;
   transition: all 400ms ease ${(props) => props.openDelay}s;


### PR DESCRIPTION
## Description

Use a ref to calculate a height based on the offsetTop of mobile modal
When its displaced by an absolute positioned header
Since the absolute header was causing the submit button sticky footer to be displayed outside the viewport

## Links

[DIST-864](https://jira.typeform.tf/browse/DIST-864)