### PR TITLE
chore(DIST-893): Added missing cloudfront id (main)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ env:
   PUBLIC_CDN_URL: "https://embed.typeform.com"
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   SEGMENT_WRITE_KEY: ${{ secrets.DEPLOYMENT_SEGMENT_WRITE_KEY }}
+  AWS_CLOUDFRONT_DIST: "E3IUO95IYL1RI3"
 
 jobs:
   init:
@@ -83,6 +84,6 @@ jobs:
       - run: yarn lerna run build
         env:
           NODE_ENV: "production"
-      - run: yarn add -W @typeform/jarvis@12.1.2-alpha.1
+      - run: yarn add -W @typeform/jarvis
       - run: sh ./packages/embed/scripts/prepare-release.sh
       - run: DEBUG=jarvis yarn run jarvis deploy --path ./packages/embed/build-aws --version next


### PR DESCRIPTION
This PR is to eliminate the following warning from the CI log:

```
jarvis Not invalidating Cloudfront cache as either $AWS_CLOUDFRONT_DIST or $PUBLIC_CDN_URL are not defined
```

Seems like this can cause jarvis to skip the cache invalidation step.