### PR TITLE
chore(DIST-893): Added missing cloudfront id (master)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
   AWS_ASSETS_BUCKET: 'typeform-public-assets/embed'
   PUBLIC_CDN_URL: 'https://embed.typeform.com'
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  AWS_CLOUDFRONT_DIST: "E3IUO95IYL1RI3"
+  AWS_CLOUDFRONT_DIST: 'E3IUO95IYL1RI3'
 
 jobs:
   init:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
   AWS_ASSETS_BUCKET: 'typeform-public-assets/embed'
   PUBLIC_CDN_URL: 'https://embed.typeform.com'
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  AWS_CLOUDFRONT_DIST: "E3IUO95IYL1RI3"
 
 jobs:
   init:


### PR DESCRIPTION
This PR is to eliminate the following warning from the CI log:

```
jarvis Not invalidating Cloudfront cache as either $AWS_CLOUDFRONT_DIST or $PUBLIC_CDN_URL are not defined
```

Seems like this can cause jarvis to skip the cache invalidation step.