### PR TITLE
fix(#274): Better way to handle empty querystring variables

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -29,7 +29,9 @@ export const appendParamsToUrl = (url, params) => {
   const parameters = Object.assign({}, query, params)
 
   Object.keys(parameters).forEach((key) => {
-    queryParameters.push(`${encodeURIComponent(key)}=${encodeURIComponent(parameters[key])}`)
+    queryParameters.push(
+      `${encodeURIComponent(key)}=${parameters[key] == null ? '' : encodeURIComponent(parameters[key])}`
+    )
   })
 
   return `${origin}${path}?${queryParameters.join('&')}${hash}`

--- a/src/core/utils/url-parameters-transfer.js
+++ b/src/core/utils/url-parameters-transfer.js
@@ -15,7 +15,7 @@ export const transferUrlParametersToQueryStrings = (transferableUrlParameters, q
   const urlSearchParams = urlSearchToParams(urlSearchString)
   const queryStringsWithTransferedParams = { ...queryStrings }
   transferableUrlParameters.forEach((transferableParam) => {
-    if (!(transferableParam in queryStrings)) {
+    if (!(transferableParam in queryStrings) && transferableParam in urlSearchParams) {
       queryStringsWithTransferedParams[transferableParam] = urlSearchParams[transferableParam]
     }
   })

--- a/src/core/utils/url-parameters-transfer.spec.js
+++ b/src/core/utils/url-parameters-transfer.spec.js
@@ -37,4 +37,10 @@ describe('transferUrlParametersToQueryStrings', () => {
       'embed-hide-footer': true,
     })
   })
+
+  it('skip missing url params', () => {
+    const randomParameter = `random-${Math.random()}`
+    const queryStringWithTransferedUrlParameters = transferUrlParametersToQueryStrings([randomParameter, 'foo'], {})
+    expect(queryStringWithTransferedUrlParameters).toStrictEqual({ foo: 'jason' })
+  })
 })

--- a/src/core/utils/url-parameters-transfer.spec.js
+++ b/src/core/utils/url-parameters-transfer.spec.js
@@ -43,4 +43,11 @@ describe('transferUrlParametersToQueryStrings', () => {
     const queryStringWithTransferedUrlParameters = transferUrlParametersToQueryStrings([randomParameter, 'foo'], {})
     expect(queryStringWithTransferedUrlParameters).toStrictEqual({ foo: 'jason' })
   })
+
+  it('ensure empty url params are accepted', () => {
+    window.location = { search: '?empty-param=&filled=value' }
+    const urlParameters = ['empty-param', 'filled']
+    const queryStringWithTransferedUrlParameters = transferUrlParametersToQueryStrings(urlParameters, {})
+    expect(queryStringWithTransferedUrlParameters).toStrictEqual({ 'empty-param': '', filled: 'value' })
+  })
 })

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -29,6 +29,16 @@ export const urls = [
     params: { mandarina: 'apple' },
     expected: 'https://url.com?mandarina=apple#naranja=yum',
   },
+  {
+    url: 'https://url.com#naranja=gracias',
+    params: { undefinedValue: undefined },
+    expected: 'https://url.com?undefinedValue=#naranja=gracias',
+  },
+  {
+    url: 'https://url.com#naranja=yummy',
+    params: { nullValue: null },
+    expected: 'https://url.com?nullValue=#naranja=yummy',
+  },
 ]
 
 export const userAgents = [


### PR DESCRIPTION
### `transferUrlParametersToQueryStrings`

Resolves #274

**Context:**
```js
window.location = 'http://localhost/?empty-param=&filled=value' 
const urlParameters = ['empty-param', 'filled', 'non-existent']
```

**Before:**
```js
console.log(transferUrlParametersToQueryStrings(urlParameters, {}))
// { 'empty-param': '', 'filled': 'value', 'non-existent': undefined }
```

**After:**
```js
console.log(transferUrlParametersToQueryStrings(urlParameters, {}))
// { 'empty-param': '', 'filled': 'value' }
```

-------------------

### `appendParamsToUrl`

**Before:**
```js
console.log(appendParamsToUrl('http://localhost/?foo=bar#some=thing', { 'undef': undefined }))
// http://localhost/?foo=bar&undef=undefined#some=thing

console.log(updateQueryStringParameter('undef', undefined, 'http://localhost/?foo=bar#some=thing'))
// 'http://localhost?foo=bar&undef=undefined#some=thing'
```

**After:**
```js
console.log(appendParamsToUrl('http://localhost/?foo=bar#some=thing', { 'undef': undefined }))
// http://localhost?foo=bar&undef=#some=thing

console.log(updateQueryStringParameter('undef', undefined, 'http://localhost/?foo=bar#some=thing'))
// 'http://localhost?foo=bar&undef=#some=thing'
```