### PR TITLE
fix(DIST-1042): Add disable submission to fake welcome screen on mobile

### DIFF
--- a/src/core/views/widget.js
+++ b/src/core/views/widget.js
@@ -60,7 +60,7 @@ const PlaceholderAnimationDisappear = keyframes`
   0% {
     opacity: 1;
   }
-  
+
   100% {
     opacity: 0;
   }
@@ -265,6 +265,7 @@ class Widget extends Component {
     if (enabledFullscreen) {
       inlineIframeUrl = updateQueryStringParameter('disable-tracking', 'true', inlineIframeUrl)
       inlineIframeUrl = updateQueryStringParameter('add-placeholder-ws', 'true', inlineIframeUrl)
+      inlineIframeUrl = updateQueryStringParameter('__dangerous-disable-submissions', 'true', inlineIframeUrl)
     }
 
     let fullscreenIframeUrl = updateQueryStringParameter('typeform-welcome', '0', url)

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -83,6 +83,7 @@ describe('Widget', () => {
       expect(wrapper.find(Iframe)).toHaveLength(1)
       expect(wrapper.find(Iframe).props().src.includes('disable-tracking=true')).toBe(true)
       expect(wrapper.find(Iframe).props().src.includes('add-placeholder-ws=true')).toBe(true)
+      expect(wrapper.find(Iframe).props().src.includes('__dangerous-disable-submissions=true')).toBe(true)
     })
 
     it('renders a second iframe after the welcome-screen-hidden event', () => {

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -100,6 +100,9 @@ describe('Widget', () => {
       modal = wrapper.find(MobileModal)
       expect(wrapper.find(MobileModal).props().url.includes('typeform-welcome=0')).toBe(true)
       expect(wrapper.find(MobileModal).props().open).toBe(true)
+      expect(wrapper.find(MobileModal).find(Iframe).props().src.includes('__dangerous-disable-submissions=true')).toBe(
+        false
+      )
     })
   })
 })


### PR DESCRIPTION
## Description

The transition between the welcome screen and the form
Causes the start-submission endpoint to be called twice
Thus registering two starts for each actual start
By adding `__dangerous-disable-submissions` it renders the welcome screen without calling the start submission endpoint

## Links

[DIST-1042](https://jira.typeform.tf/browse/DIST-1042)