### PR TITLE
fix(DIST-1042): Allow embedding inline widget on mobile

### DIFF
--- a/src/core/views/widget.js
+++ b/src/core/views/widget.js
@@ -261,7 +261,7 @@ class Widget extends Component {
 
     let inlineIframeUrl = updateQueryStringParameter('typeform-embed-id', this.embedId, url)
 
-    if (enabledFullscreen) {
+    if (enabledFullscreen && !inlineIframeUrl.includes('typeform-welcome=0')) {
       inlineIframeUrl = updateQueryStringParameter('disable-tracking', 'true', inlineIframeUrl)
       inlineIframeUrl = updateQueryStringParameter('add-placeholder-ws', 'true', inlineIframeUrl)
       inlineIframeUrl = updateQueryStringParameter('__dangerous-disable-submissions', 'true', inlineIframeUrl)

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -86,6 +86,14 @@ describe('Widget', () => {
       expect(wrapper.find(Iframe).props().src.includes('__dangerous-disable-submissions=true')).toBe(true)
     })
 
+    it('renders an iframe without disabled submissions and placeholder welcome screen when URL contains "typeform-welcome=0"', () => {
+      const wrapper = mount(<Widget enabledFullscreen url={`${URL}?typeform-welcome=0`} />)
+      expect(wrapper.find(Iframe)).toHaveLength(1)
+      expect(wrapper.find(Iframe).props().src.includes('disable-tracking=true')).toBe(false)
+      expect(wrapper.find(Iframe).props().src.includes('add-placeholder-ws=true')).toBe(false)
+      expect(wrapper.find(Iframe).props().src.includes('__dangerous-disable-submissions=true')).toBe(false)
+    })
+
     it('renders a second iframe after the welcome-screen-hidden event', () => {
       const wrapper = mount(<Widget enabledFullscreen url={URL} />)
 


### PR DESCRIPTION
Adding param 'typeform-welcome=0' to query string of the form URL will render it as inline widget even on mobile. Do not disable submissions or tracking in this case.