### PR TITLE
feat(DIST-1005): Close embed on Keyboard event

### DIFF
--- a/packages/embed/e2e/spec/functional/close-on-keyboard.spec.ts
+++ b/packages/embed/e2e/spec/functional/close-on-keyboard.spec.ts
@@ -1,0 +1,31 @@
+describe('Close on Keyboard Esc Event', () => {
+  it('Should close the form with keyboard event inside the Iframe', () => {
+    cy.visit('/popup-html.html')
+
+    cy.get('#button').click()
+
+    cy.get('iframe').should('be.visible')
+
+    cy.get('iframe').then(($iframe) => {
+      const $body = $iframe.contents().find('body')
+      // interact with Iframe
+      cy.wrap($body).find('[data-value-number="2"]').click()
+      // close with keyboard inside iframe
+      cy.wrap($body).find('textarea').type('{esc}')
+    })
+
+    cy.get('iframe').should('not.exist')
+  })
+
+  it('Should close the form with keyboard event from host window', () => {
+    cy.visit('/popup-html.html')
+
+    cy.get('#button').click()
+
+    cy.get('iframe').should('be.visible')
+    // close with keyboard from host page
+    cy.get('body').click().trigger('keydown', { key: 27, code: 'Escape', release: false })
+
+    cy.get('iframe').should('not.exist')
+  })
+})

--- a/packages/embed/src/factories/create-popover/create-popover.ts
+++ b/packages/embed/src/factories/create-popover/create-popover.ts
@@ -1,4 +1,11 @@
-import { createIframe, setElementSize, handleCustomOpen, unmountElement, setAutoClose } from '../../utils'
+import {
+  createIframe,
+  setElementSize,
+  handleCustomOpen,
+  unmountElement,
+  setAutoClose,
+  addCustomKeyboardListener,
+} from '../../utils'
 
 import { PopoverOptions } from './popover-options'
 import { buildNotificationDot, canBuildNotificationDot, saveNotificationDotHideUntilTime } from './notification-days'
@@ -163,6 +170,7 @@ export const createPopover = (formId: string, userOptions: PopoverOptions = {}):
     popover.classList.add('open')
     wrapper.style.opacity = '1'
     replaceIcon(spinner, closeIcon)
+    addCustomKeyboardListener(close)
   }
 
   const open = () => {

--- a/packages/embed/src/factories/create-popup/create-popup.ts
+++ b/packages/embed/src/factories/create-popup/create-popup.ts
@@ -6,6 +6,7 @@ import {
   handleCustomOpen,
   unmountElement,
   setAutoClose,
+  addCustomKeyboardListener,
 } from '../../utils'
 import { POPUP_SIZE } from '../../constants'
 
@@ -92,6 +93,7 @@ export const createPopup = (formId: string, userOptions: PopupOptions = {}): Pop
     setTimeout(() => {
       spinner.style.display = 'none'
     }, 250)
+    addCustomKeyboardListener(close)
   }
 
   const open = () => {

--- a/packages/embed/src/factories/create-sidetab/create-sidetab.ts
+++ b/packages/embed/src/factories/create-sidetab/create-sidetab.ts
@@ -1,4 +1,11 @@
-import { createIframe, setElementSize, handleCustomOpen, unmountElement, setAutoClose } from '../../utils'
+import {
+  createIframe,
+  setElementSize,
+  handleCustomOpen,
+  unmountElement,
+  setAutoClose,
+  addCustomKeyboardListener,
+} from '../../utils'
 
 import { SidetabOptions } from './sidetab-options'
 
@@ -114,6 +121,7 @@ export const createSidetab = (formId: string, userOptions: SidetabOptions = {}):
   iframe.onload = () => {
     sidetab.classList.add('open')
     replaceElementChild(spinner, closeIcon)
+    addCustomKeyboardListener(close)
   }
 
   const open = () => {

--- a/packages/embed/src/factories/create-slider/create-slider.ts
+++ b/packages/embed/src/factories/create-slider/create-slider.ts
@@ -1,4 +1,12 @@
-import { createIframe, hasDom, setElementSize, handleCustomOpen, unmountElement, setAutoClose } from '../../utils'
+import {
+  createIframe,
+  hasDom,
+  setElementSize,
+  handleCustomOpen,
+  unmountElement,
+  setAutoClose,
+  addCustomKeyboardListener,
+} from '../../utils'
 import { SLIDER_POSITION, SLIDER_WIDTH } from '../../constants'
 
 import { SliderOptions } from './slider-options'
@@ -75,6 +83,8 @@ export const createSlider = (formId: string, userOptions: SliderOptions = {}): S
     setTimeout(() => {
       spinner.style.display = 'none'
     }, 500)
+
+    addCustomKeyboardListener(close)
   }
 
   const open = () => {

--- a/packages/embed/src/utils/create-iframe/create-iframe.ts
+++ b/packages/embed/src/utils/create-iframe/create-iframe.ts
@@ -5,6 +5,7 @@ import { setupGaInstance } from '../'
 import { generateEmbedId } from './generate-embed-id'
 import { getFormReadyHandler, getFormQuestionChangedHandler, getFormSubmitHandler } from './get-form-event-handler'
 import { triggerIframeRedraw } from './trigger-iframe-redraw'
+import { dispatchCustomKeyEventFromIframe } from './setup-custom-keyboard-close'
 
 export const createIframe = (formId: string, type: EmbedType, options: CreateIframeOptions) => {
   const embedId = generateEmbedId()
@@ -18,6 +19,10 @@ export const createIframe = (formId: string, type: EmbedType, options: CreateIfr
   window.addEventListener('message', getFormReadyHandler(embedId, options.onReady))
   window.addEventListener('message', getFormQuestionChangedHandler(embedId, options.onQuestionChanged))
   window.addEventListener('message', getFormSubmitHandler(embedId, options.onSubmit))
+
+  if (type !== 'widget') {
+    window.addEventListener('message', dispatchCustomKeyEventFromIframe)
+  }
 
   if (options.shareGaInstance) {
     window.addEventListener(

--- a/packages/embed/src/utils/create-iframe/index.ts
+++ b/packages/embed/src/utils/create-iframe/index.ts
@@ -1,1 +1,2 @@
 export * from './create-iframe'
+export * from './setup-custom-keyboard-close'

--- a/packages/embed/src/utils/create-iframe/setup-custom-keyboard-close.ts
+++ b/packages/embed/src/utils/create-iframe/setup-custom-keyboard-close.ts
@@ -1,0 +1,20 @@
+const POST_MESSAGE = 'form-close'
+const KEY_EVENT = 'Escape'
+
+const closeOnKeyEvent = async (evt: KeyboardEvent, close?: () => void) => {
+  if (evt.code === KEY_EVENT && typeof close === 'function') {
+    close()
+    removeCustomKeyboardListener()
+  }
+}
+
+export const addCustomKeyboardListener = (callback: () => void) =>
+  window.document.addEventListener('keydown', (evt) => closeOnKeyEvent(evt, callback))
+
+export const removeCustomKeyboardListener = () => window.document.removeEventListener('keydown', closeOnKeyEvent)
+
+export const dispatchCustomKeyEventFromIframe = (evt: MessageEvent) => {
+  if (evt.data.type === POST_MESSAGE) {
+    window.document.dispatchEvent(new KeyboardEvent('keydown', { code: KEY_EVENT }))
+  }
+}


### PR DESCRIPTION
Ticket [DIST-1005](https://jira.typeform.tf/browse/DIST-1005)
Closes Embed on Esc Key. 
ACs: 

1. form is embedded (all embeds except widget)
2. user opens the modal window
3. form is displayed
4. user presses ESC key
5. modal is closed
6. form is not displayed
