### PR TITLE
feat(DIST-1126): Allow reloading and loading snippets in page

### DIFF
--- a/packages/demo-html/public/reload-event.html
+++ b/packages/demo-html/public/reload-event.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Static HTML Demo</title>
+    <style>
+      .column {
+        float: left;
+        width: 46%;
+        padding: 0 2%;
+      }
+      .form {
+        width: 100%;
+        height: 400px;
+        margin: 0 auto;
+      }
+    </style>
+    <script src="./lib/embed-next.js"></script>
+  </head>
+  <body>
+    <div class="column">
+      <h1>Async widget</h1>
+      <div id="wrapper">
+        <p>We will inject embed code here 3 seconds after the page has loaded.</p>
+        <p>Click the buttons below when this text is gone.</p>
+      </div>
+      <p></p>
+    </div>
+    <div class="column">
+      <h1>Standard widget</h1>
+      <div data-tf-widget="jAJ5qj" class="form"></div>
+    </div>
+    <div style="clear: both"></div>
+    <p>Use the buttons below when new widget is injected into the left column.</p>
+    <p>Load new embeds only: <button onClick="window.tf.load()">load</button></p>
+    <p>Reload all embeds in the page: <button onClick="window.tf.reload()">reload</button></p>
+
+    <script>
+      window.onload = () => {
+        setTimeout(() => {
+          document.querySelector('#wrapper').innerHTML = '<div data-tf-widget="jAJ5qj" class="form"></div>'
+        }, 3000)
+      }
+    </script>
+  </body>
+</html>

--- a/packages/embed/src/browser.ts
+++ b/packages/embed/src/browser.ts
@@ -6,16 +6,24 @@ import {
   initializeWidgets,
 } from './initializers'
 
-import * as tf from './index'
+import * as lib from './index'
 
-module.exports = tf
-
-function loadEmbedElements() {
-  initializePopovers()
-  initializePopups()
-  initializeSidetabs()
-  initializeSliders()
-  initializeWidgets()
+function loadEmbedElements(forceReload: boolean = false) {
+  initializePopovers(forceReload)
+  initializePopups(forceReload)
+  initializeSidetabs(forceReload)
+  initializeSliders(forceReload)
+  initializeWidgets(forceReload)
 }
 
-document.addEventListener('DOMContentLoaded', loadEmbedElements, false)
+const reload = () => loadEmbedElements(true)
+
+const load = () => loadEmbedElements(false)
+
+module.exports = {
+  ...lib,
+  load,
+  reload,
+}
+
+document.addEventListener('DOMContentLoaded', load, false)

--- a/packages/embed/src/initializers/initialize-popovers.ts
+++ b/packages/embed/src/initializers/initialize-popovers.ts
@@ -1,22 +1,11 @@
 import { createPopover } from '../factories/create-popover'
-import { includeCss } from '../utils'
 import { POPOVER_ATTRIBUTE } from '../constants'
 
-import { buildOptionsFromAttributes } from './build-options-from-attributes'
+import { initialize } from './initialize'
 
-export const initializePopovers = () => {
-  const popoverElements = document.querySelectorAll<HTMLElement>(`[${POPOVER_ATTRIBUTE}]`)
-
-  if (popoverElements.length > 0) {
-    includeCss('popover.css')
-  }
-
-  Array.from(popoverElements).forEach((button, index) => {
-    const formId = button.getAttribute(POPOVER_ATTRIBUTE)
-    if (!formId) {
-      throw new Error(`Invalid ${POPOVER_ATTRIBUTE}=${formId} for popover embed #${index}`)
-    }
-    const { toggle } = createPopover(formId, buildOptionsFromAttributes(button))
+export const initializePopovers = (forceReload: boolean = false) => {
+  initialize(POPOVER_ATTRIBUTE, 'popover.css', forceReload, (formId, options, button) => {
+    const { toggle } = createPopover(formId, options)
     button.onclick = toggle
   })
 }

--- a/packages/embed/src/initializers/initialize-popups.ts
+++ b/packages/embed/src/initializers/initialize-popups.ts
@@ -1,22 +1,10 @@
 import { createPopup } from '../factories/create-popup'
-import { includeCss } from '../utils'
 import { POPUP_ATTRIBUTE } from '../constants'
 
-import { buildOptionsFromAttributes } from './build-options-from-attributes'
+import { initialize } from './initialize'
 
-export const initializePopups = () => {
-  const popupElements = document.querySelectorAll<HTMLElement>(`[${POPUP_ATTRIBUTE}]`)
-
-  if (popupElements.length > 0) {
-    includeCss('popup.css')
-  }
-
-  Array.from(popupElements).forEach((button, index) => {
-    const formId = button.getAttribute(POPUP_ATTRIBUTE)
-    if (!formId) {
-      throw new Error(`Invalid ${POPUP_ATTRIBUTE}=${formId} for popup embed #${index}`)
-    }
-    const options = buildOptionsFromAttributes(button)
+export const initializePopups = (forceReload: boolean = false) => {
+  initialize(POPUP_ATTRIBUTE, 'popup.css', forceReload, (formId, options, button) => {
     const { toggle } = createPopup(formId, options)
     button.onclick = toggle
   })

--- a/packages/embed/src/initializers/initialize-sidetabs.ts
+++ b/packages/embed/src/initializers/initialize-sidetabs.ts
@@ -1,23 +1,10 @@
 import { createSidetab } from '../factories/create-sidetab'
-import { includeCss } from '../utils'
 import { SIDETAB_ATTRIBUTE } from '../constants'
 
-import { buildOptionsFromAttributes } from './build-options-from-attributes'
+import { initialize } from './initialize'
 
-export const initializeSidetabs = () => {
-  const sidetabElements = document.querySelectorAll<HTMLElement>(`[${SIDETAB_ATTRIBUTE}]`)
-
-  if (sidetabElements.length) {
-    includeCss('sidetab.css')
-  }
-
-  Array.from(sidetabElements).forEach((button, index) => {
-    const formId = button.getAttribute(SIDETAB_ATTRIBUTE)
-
-    if (!formId) {
-      throw new Error(`Invalid ${SIDETAB_ATTRIBUTE}=${formId} for sidetab embed #${index}`)
-    }
-
-    createSidetab(formId, buildOptionsFromAttributes(button))
+export const initializeSidetabs = (forceReload: boolean = false) => {
+  initialize(SIDETAB_ATTRIBUTE, 'sidetab.css', forceReload, (formId, options) => {
+    createSidetab(formId, options)
   })
 }

--- a/packages/embed/src/initializers/initialize-sliders.ts
+++ b/packages/embed/src/initializers/initialize-sliders.ts
@@ -1,22 +1,10 @@
 import { createSlider } from '../factories/create-slider'
-import { includeCss } from '../utils'
 import { SLIDER_ATTRIBUTE } from '../constants'
 
-import { buildOptionsFromAttributes } from './build-options-from-attributes'
+import { initialize } from './initialize'
 
-export const initializeSliders = () => {
-  const sliderElements = document.querySelectorAll<HTMLElement>(`[${SLIDER_ATTRIBUTE}]`)
-
-  if (sliderElements.length > 0) {
-    includeCss('slider.css')
-  }
-
-  Array.from(sliderElements).forEach((button, index) => {
-    const formId = button.getAttribute(SLIDER_ATTRIBUTE)
-    if (!formId) {
-      throw new Error(`Invalid ${SLIDER_ATTRIBUTE}=${formId} for popup embed #${index}`)
-    }
-    const options = buildOptionsFromAttributes(button)
+export const initializeSliders = (forceReload: boolean = false) => {
+  initialize(SLIDER_ATTRIBUTE, 'slider.css', forceReload, (formId, options, button) => {
     const { toggle } = createSlider(formId, options)
     button.onclick = toggle
   })

--- a/packages/embed/src/initializers/initialize-widgets.ts
+++ b/packages/embed/src/initializers/initialize-widgets.ts
@@ -1,21 +1,10 @@
 import { createWidget } from '../factories/create-widget'
-import { includeCss } from '../utils'
 import { WIDGET_ATTRIBUTE } from '../constants'
 
-import { buildOptionsFromAttributes } from './build-options-from-attributes'
+import { initialize } from './initialize'
 
-export const initializeWidgets = () => {
-  const widgetElements = document.querySelectorAll<HTMLElement>(`[${WIDGET_ATTRIBUTE}]`)
-
-  if (widgetElements.length > 0) {
-    includeCss('widget.css')
-  }
-
-  Array.from(widgetElements).forEach((container, index) => {
-    const formId = container.getAttribute(WIDGET_ATTRIBUTE)
-    if (!formId) {
-      throw new Error(`Invalid ${WIDGET_ATTRIBUTE}=${formId} for widget embed #${index}`)
-    }
-    createWidget(formId, { ...buildOptionsFromAttributes(container), container })
+export const initializeWidgets = (forceReload: boolean = false) => {
+  initialize(WIDGET_ATTRIBUTE, 'widget.css', forceReload, (formId, options, container) => {
+    createWidget(formId, { ...options, container })
   })
 }

--- a/packages/embed/src/initializers/initialize.ts
+++ b/packages/embed/src/initializers/initialize.ts
@@ -1,0 +1,27 @@
+import { includeCss } from '../utils'
+
+import { buildOptionsFromAttributes } from './build-options-from-attributes'
+
+export const initialize = (
+  embedElementAttribute: string,
+  cssFilename: string,
+  forceReload: boolean = false,
+  factoryMethod: (id: string, options: any, element: HTMLElement) => void
+) => {
+  const embedTypeElements = document.querySelectorAll<HTMLElement>(`[${embedElementAttribute}]`)
+
+  if (embedTypeElements.length > 0) {
+    includeCss(cssFilename)
+  }
+
+  Array.from(embedTypeElements).forEach((element, index) => {
+    if (forceReload || element.dataset.tfLoaded !== 'true') {
+      const formId = element.getAttribute(embedElementAttribute)
+      if (!formId) {
+        throw new Error(`Invalid ${embedElementAttribute}=${formId} for embed #${index}`)
+      }
+      factoryMethod(formId, buildOptionsFromAttributes(element), element)
+      element.dataset.tfLoaded = 'true'
+    }
+  })
+}


### PR DESCRIPTION
When you inject embed snippet to the page later, you can load it manually via `window.tf.load()`.
You can reloading all existing embed snippets in the page via `window.tf.reload()`.