### PR TITLE
fix(DIST-1131): Allow comas in hidden fields

### DIFF
--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -106,8 +106,9 @@ Or from admin panel URL:
 - define options as data attributes with `data-tf-` prefix and dashes in name (eg. `disableAutoFocus` becomes `data-tf-disable-autofocus`)
 - set a boolean property to `true` by omitting attribute value, (eg. `<div ... data-tf-disable-footer></div>`
 - pass function name for callbacks, eg. `data-tf-on-ready="myReadyFunction"` if this function is available on global scope (eg. `window`)
-- to pass `string[]` use coma-separated string, eg. `transitiveSearchParams: ['foo', 'bar']` becomes `data-tf-transitive-search-params="foo,bar"`
-- to pass `object` pass coma-separated key=value pairs, eg. `hidden: { foo: "f", bar: "b" }` becomes `data-tf-hidden="foo=f,bar=b"`
+- to pass `string[]` use comma-separated string, eg. `transitiveSearchParams: ['foo', 'bar']` becomes `data-tf-transitive-search-params="foo,bar"`
+- to pass `object` pass comma-separated key=value pairs, eg. `hidden: { foo: "f", bar: "b" }` becomes `data-tf-hidden="foo=f,bar=b"`
+  - **Note:** since commas `,` are used as delimiter for each value you will need to escape them with backward slash, eg. `data-tf-hidden="foo=foo\,bar"`. In JavaScript you don't need to escape it.
 
 ### Custom Launch Options
 
@@ -163,7 +164,7 @@ Callback method receive payload object from the form:
   - `ref` (string) identifies currenttly displayed question
 - onSubmit
   - `responseId` (string) identifies the response, can be retrieved via [Responses API](https://developer.typeform.com/responses/)
-  - `response_id` (string) same as above (for backward comaptibility with old embed SDK)
+  - `response_id` (string) same as above (for backward compatibility with old embed SDK)
 
 See [callbacks example in demo package](../../packages/demo-html/public/callbacks.html).
 

--- a/packages/embed/src/utils/load-options-from-attributes.spec.ts
+++ b/packages/embed/src/utils/load-options-from-attributes.spec.ts
@@ -87,6 +87,10 @@ describe('load-options-from-attributes', () => {
       expect(transformAttributeValue('a, b', 'array')).toEqual(['a', 'b'])
     })
 
+    it('should transform string with escaped commas as array', () => {
+      expect(transformAttributeValue('a, b, c\\,d', 'array')).toEqual(['a', 'b', 'c,d'])
+    })
+
     it('should remove empty spaces around text', () => {
       expect(transformAttributeValue('foo , bar , test', 'array')).toEqual(['foo', 'bar', 'test'])
     })
@@ -103,6 +107,10 @@ describe('load-options-from-attributes', () => {
   describe('to record (object)', () => {
     it('should transform string as record', () => {
       expect(transformAttributeValue('a=aa, b=bb', 'record')).toEqual({ a: 'aa', b: 'bb' })
+    })
+
+    it('should transform string with escaped commas as record', () => {
+      expect(transformAttributeValue('a=a\\,a, b\\,b=bb', 'record')).toEqual({ a: 'a,a', 'b,b': 'bb' })
     })
 
     it('should remove empty spaces in values, not around keys', () => {

--- a/packages/embed/src/utils/load-options-from-attributes.ts
+++ b/packages/embed/src/utils/load-options-from-attributes.ts
@@ -30,21 +30,29 @@ const transformFunction = (value: string | null): Function | undefined => {
   return typeof fn === 'function' ? fn : undefined
 }
 
+const COMMA_PLACEHOLDER = '%ESCAPED_COMMA%'
+
 const transformArray = (value: string | null): string[] | undefined => {
   if (!value) {
     return undefined
   }
   return value
-    ?.replace(/\s/g, '')
+    .replace(/\s/g, '')
+    .replace(/\\,/g, COMMA_PLACEHOLDER)
     .split(',')
     .filter((v) => !!v)
+    .map((v) => v.replace(COMMA_PLACEHOLDER, ','))
 }
 
 const transformRecord = (value: string | null): Record<string, string> | undefined => {
   if (!value) {
     return undefined
   }
-  const arrayOfRecordStrings = value.split(',').filter((v) => !!v)
+  const arrayOfRecordStrings = value
+    .replace(/\\,/g, COMMA_PLACEHOLDER)
+    .split(',')
+    .filter((v) => !!v)
+    .map((v) => v.replace(COMMA_PLACEHOLDER, ','))
   return arrayOfRecordStrings.reduce((record, recordString) => {
     const match = recordString.match(/^([^=]+)=(.*)$/)
     if (match) {


### PR DESCRIPTION
Array and object attributes can have values with coma. It needs to be escaped with backward slash.