### PR TITLE
fix(DIST-1161): Fix height on mobile

### DIFF
--- a/packages/embed/src/css/includes/_fullsize.scss
+++ b/packages/embed/src/css/includes/_fullsize.scss
@@ -3,4 +3,6 @@
   height: 100% !important;
   width: 100vw !important;
   height: 100vh !important;
+  max-height: -webkit-fill-available;
+  max-height: -moz-fill-available;
 }

--- a/packages/embed/src/css/popover.scss
+++ b/packages/embed/src/css/popover.scss
@@ -15,6 +15,8 @@
   right: 16px;
   z-index: 10001;
 
+
+
   &.open {
     max-width: 100%;
     min-height: 360px;
@@ -169,6 +171,7 @@
       bottom: 0;
       right: 0;
       @include fullsize;
+      max-height: -webkit-fill-available;
 
       .typeform-popover-close {
         display: block;

--- a/packages/embed/src/css/popover.scss
+++ b/packages/embed/src/css/popover.scss
@@ -15,8 +15,6 @@
   right: 16px;
   z-index: 10001;
 
-
-
   &.open {
     max-width: 100%;
     min-height: 360px;

--- a/packages/embed/src/css/popover.scss
+++ b/packages/embed/src/css/popover.scss
@@ -169,7 +169,6 @@
       bottom: 0;
       right: 0;
       @include fullsize;
-      max-height: -webkit-fill-available;
 
       .typeform-popover-close {
         display: block;


### PR DESCRIPTION
Ticket [DIST-1161](https://jira.typeform.tf/browse/DIST-1161)

### Issue 
The height of the root container is set to `100%vh` when embedded in  in mobile, that height exceed the height of the device.
testable broken typeform on https://embedtestsite.000webhostapp.com/basic-typeform/

### Fix
Sets the max height of the root to be not greater than the window.innerHeight, only for mobile devices 