### PR TITLE
fix(DIST-1183): Load embed elements on lib load

### DIFF
--- a/packages/demo-html/public/behavioral-html/exit-html.html
+++ b/packages/demo-html/public/behavioral-html/exit-html.html
@@ -39,8 +39,8 @@
       <input id="threshold" name="threshold" type="number" value="50" step="10" min="10" max="250" />
       <button type="submit">Set</button>
     </form>
-    <script src="../lib/embed-next.js"></script>
     <script>
+      // if we want to modify embed code snippets we need to do it before loading embed-next.js
       const threshold = parseInt(new URL(window.location.href).searchParams.get('threshold'), 10)
       if (threshold) {
         document.getElementById('visual-threshold').style.height = threshold + 'px'
@@ -48,5 +48,6 @@
         document.getElementById('threshold').value = threshold
       }
     </script>
+    <script src="../lib/embed-next.js"></script>
   </body>
 </html>

--- a/packages/demo-html/public/client-side.html
+++ b/packages/demo-html/public/client-side.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Client-side Snippet Demo</title>
+    <style>
+      #wrapper {
+        width: 100%;
+        max-width: 600px;
+        height: 400px;
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>This page will inject embed code client-side with JS</h1>
+    <p>This embed code is inserted before the JS lib is loaded and will load automatically.</p>
+    <div id="content"></div>
+    <p>
+      Embed code here is inserted later, after the JS lib is loaded and needs to be loaded manually via
+      <code>window.tf.load()</code>.
+    </p>
+    <div id="more-content"></div>
+    <script>
+      // add snippet
+      const contentElm = document.querySelector('#content')
+      contentElm.innerHTML = '<div id="wrapper" data-tf-widget="moe6aa"></div>'
+
+      // add script (we can not add scripts via innerHTML)
+      const scriptElm = document.createElement('script')
+      scriptElm.src = './lib/embed-next.js'
+      document.querySelector('body').append(scriptElm)
+
+      setTimeout(() => {
+        const moreContentElm = document.querySelector('#more-content')
+        moreContentElm.innerHTML =
+          'Embed code inserted but not loaded. <button onclick="window.tf.load()">run <code>window.tf.load()</code></button>' +
+          '<div id="wrapper" data-tf-widget="moe6aa"></div>'
+      }, 2000)
+    </script>
+  </body>
+</html>

--- a/packages/embed/e2e/spec/functional/client-side.spec.ts
+++ b/packages/embed/e2e/spec/functional/client-side.spec.ts
@@ -1,0 +1,33 @@
+describe('Widget laoded client-side', () => {
+  before(() => {
+    cy.visit('/client-side.html')
+  })
+
+  it('should display widget', () => {
+    cy.get('#content .typeform-widget iframe').should('be.visible')
+    cy.get('#content .typeform-widget iframe').invoke('attr', 'src').should('contain', 'form.typeform.com/to/')
+  })
+
+  it('should not display widget added after lib is loaded', () => {
+    cy.get('#more-content .typeform-widget').should('not.exist')
+  })
+
+  it('should display only 1 widget', () => {
+    cy.get('.typeform-widget iframe').should('have.length', 1)
+  })
+
+  describe('when window.tf.load() is called', () => {
+    before(() => {
+      cy.get('button').click()
+    })
+
+    it('should display second widget', () => {
+      cy.get('#more-content .typeform-widget iframe').should('be.visible')
+      cy.get('#more-content .typeform-widget iframe').invoke('attr', 'src').should('contain', 'form.typeform.com/to/')
+    })
+
+    it('should display 2 widgets now', () => {
+      cy.get('.typeform-widget iframe').should('have.length', 2)
+    })
+  })
+})

--- a/packages/embed/src/browser.ts
+++ b/packages/embed/src/browser.ts
@@ -27,3 +27,5 @@ module.exports = {
 }
 
 document.addEventListener('DOMContentLoaded', load, false)
+
+load()


### PR DESCRIPTION
Load also on lib load, not only on page load. In some cases the lib is injected into the page later,
after the page is already loaded and we want to load all embeds in the page at that time.