### PR TITLE
fix(DIST-1199): Enable submission for fake welcome screen on mobile

### DIFF
--- a/src/core/views/widget.js
+++ b/src/core/views/widget.js
@@ -60,6 +60,7 @@ const PlaceholderAnimationDisappear = keyframes`
   0% {
     opacity: 1;
   }
+  
   100% {
     opacity: 0;
   }
@@ -264,7 +265,6 @@ class Widget extends Component {
     if (enabledFullscreen && !inlineIframeUrl.includes('typeform-welcome=0')) {
       inlineIframeUrl = updateQueryStringParameter('disable-tracking', 'true', inlineIframeUrl)
       inlineIframeUrl = updateQueryStringParameter('add-placeholder-ws', 'true', inlineIframeUrl)
-      inlineIframeUrl = updateQueryStringParameter('__dangerous-disable-submissions', 'true', inlineIframeUrl)
     }
 
     let fullscreenIframeUrl = updateQueryStringParameter('typeform-welcome', '0', url)

--- a/src/core/views/widget.spec.js
+++ b/src/core/views/widget.spec.js
@@ -83,7 +83,6 @@ describe('Widget', () => {
       expect(wrapper.find(Iframe)).toHaveLength(1)
       expect(wrapper.find(Iframe).props().src.includes('disable-tracking=true')).toBe(true)
       expect(wrapper.find(Iframe).props().src.includes('add-placeholder-ws=true')).toBe(true)
-      expect(wrapper.find(Iframe).props().src.includes('__dangerous-disable-submissions=true')).toBe(true)
     })
 
     it('renders an iframe without disabled submissions and placeholder welcome screen when URL contains "typeform-welcome=0"', () => {
@@ -108,9 +107,6 @@ describe('Widget', () => {
       modal = wrapper.find(MobileModal)
       expect(wrapper.find(MobileModal).props().url.includes('typeform-welcome=0')).toBe(true)
       expect(wrapper.find(MobileModal).props().open).toBe(true)
-      expect(wrapper.find(MobileModal).find(Iframe).props().src.includes('__dangerous-disable-submissions=true')).toBe(
-        false
-      )
     })
   })
 })


### PR DESCRIPTION
Remove disable submission from fake welcome screen on mobile. Some respondents are able to interact
with the placeholder form but we are unable to replicate this.

This will break insights (DIST-1042), but it will prevent losing submissions.

This reverts commit 8c50ecaad8786681e1247a55e8c0e1b91df1ca70 (PR #278).

Closes #318