### PR TITLE
fix(DIST-1195): Load embed snippets after the page has loaded

### DIFF
--- a/packages/demo-html/public/callbacks.html
+++ b/packages/demo-html/public/callbacks.html
@@ -13,7 +13,19 @@
     </style>
   </head>
   <body>
+    <div
+      id="wrapper"
+      data-tf-widget="moe6aa"
+      data-tf-source="localhost"
+      data-tf-on-ready="onTypeformReady"
+      data-tf-on-submit="onTypeformSubmit"
+      data-tf-on-question-changed="onTypeformQuestionChanged"
+    ></div>
+    <script src="./lib/embed-next.js"></script>
     <script>
+      // customers are often defining callbacks AFTER embedding the form
+      // https://github.com/Typeform/embed/issues/363
+
       function onTypeformReady(data) {
         alert('onReady')
         console.log('form ready', data)
@@ -29,14 +41,5 @@
         console.log('form question changed', data)
       }
     </script>
-    <div
-      id="wrapper"
-      data-tf-widget="moe6aa"
-      data-tf-source="localhost"
-      data-tf-on-ready="onTypeformReady"
-      data-tf-on-submit="onTypeformSubmit"
-      data-tf-on-question-changed="onTypeformQuestionChanged"
-    ></div>
-    <script src="./lib/embed-next.js"></script>
   </body>
 </html>

--- a/packages/demo-html/public/client-side.html
+++ b/packages/demo-html/public/client-side.html
@@ -27,17 +27,22 @@
       const contentElm = document.querySelector('#content')
       contentElm.innerHTML = '<div id="wrapper" data-tf-widget="moe6aa"></div>'
 
-      // add script (we can not add scripts via innerHTML)
-      const scriptElm = document.createElement('script')
-      scriptElm.src = './lib/embed-next.js'
-      document.querySelector('body').append(scriptElm)
+      setTimeout(() => {
+        console.log('Is document already loaded?', document.readyState === 'complete' ? 'YES' : 'NO')
+        console.log('document.readyState =', document.readyState)
+
+        // add script (we can not add scripts via innerHTML)
+        const scriptElm = document.createElement('script')
+        scriptElm.src = './lib/embed-next.js'
+        document.querySelector('body').append(scriptElm)
+      }, 500)
 
       setTimeout(() => {
         const moreContentElm = document.querySelector('#more-content')
         moreContentElm.innerHTML =
           'Embed code inserted but not loaded. <button onclick="window.tf.load()">run <code>window.tf.load()</code></button>' +
           '<div id="wrapper" data-tf-widget="moe6aa"></div>'
-      }, 2000)
+      }, 3000)
     </script>
   </body>
 </html>

--- a/packages/embed/src/browser.ts
+++ b/packages/embed/src/browser.ts
@@ -28,4 +28,6 @@ module.exports = {
 
 document.addEventListener('DOMContentLoaded', load, false)
 
-load()
+if (document.readyState === 'interactive' || document.readyState === 'complete') {
+  load()
+}


### PR DESCRIPTION
When lib is included in page before DOMContentLoaded event, wait for the event.
When it is included after page load, load snippets right away (based on document.readyState).

Resolves #363