### PR TITLE
fix(DIST-1432): Prevent text from being hidden by ellipsis in side tab

### DIFF
--- a/packages/embed/src/css/sidetab.scss
+++ b/packages/embed/src/css/sidetab.scss
@@ -37,9 +37,11 @@
   &-button {
     position: absolute;
     top: 50%;
-    transform: rotate(-90deg);
-    transform-origin: bottom left;
-    width: 200px;
+    left: -48px;
+    transform: rotate(-90deg) translateX(-50%);
+    transform-origin: left top;
+    min-width: 100px;
+    max-width: 540px;
     height: 48px;
     display: flex;
     align-items: center;


### PR DESCRIPTION
<img width="135" alt="Screenshot 2021-11-29 at 11 43 22" src="https://user-images.githubusercontent.com/1560118/143853920-36024a58-616e-4d10-ac83-b1b20ee0cb0e.png">
