### PR TITLE
fix(DIST-1237): ModalWindowOptions['autoClose'] can also be a boolean

### DIFF
--- a/packages/embed/src/base/modal-window-options.ts
+++ b/packages/embed/src/base/modal-window-options.ts
@@ -8,11 +8,13 @@ export type ModalWindowOptions = {
   /**
    * Time (ms) until the embedded typeform will automatically close after a respondent clicks the Submit button.
    *
-   * @type {number}
+   * @type {number|boolean}
    */
-  autoClose?: number
+  autoClose?: number | boolean
   /**
    * Reopen the modal window with form in the same state (on the same question) as it was when closed.
+   *
+   * @type {boolean}
    */
   keepSession?: boolean
 }


### PR DESCRIPTION
By the way, shouldn't these JSDoc declarations include `undefined`?

Also, isn't it safer to end those lines with a semi-colon? I've never seen types declared like that, without semi-colons. Even tsc outputs them in *.d.ts* files.