### PR TITLE
fix(DIST-1525): read the nonce from a bundler-safe location

### DIFF
--- a/packages/embed-react/src/components/inline-style.spec.tsx
+++ b/packages/embed-react/src/components/inline-style.spec.tsx
@@ -3,14 +3,6 @@ import { render, screen } from '@testing-library/react'
 
 import { InlineStyle } from './inline-style'
 
-declare global {
-  namespace NodeJS {
-    interface Global {
-      __webpack_nonce__: string
-    }
-  }
-}
-
 describe('<InlineStyle />', () => {
   it('should render inline CSS', () => {
     render(

--- a/packages/embed-react/src/utils/nonce.ts
+++ b/packages/embed-react/src/utils/nonce.ts
@@ -1,5 +1,11 @@
-declare let __webpack_nonce__: string
+declare global {
+  namespace NodeJS {
+    interface Global {
+      __webpack_nonce__: string
+    }
+  }
+}
 
 export default function getNonce() {
-  return typeof __webpack_nonce__ !== 'undefined' ? __webpack_nonce__ : null
+  return typeof global.__webpack_nonce__ !== 'undefined' ? global.__webpack_nonce__ : null
 }


### PR DESCRIPTION
## Purpose

As I mentioned [in this comment](https://github.com/Typeform/embed/issues/458#issuecomment-1043760286) I think I made a mistake in how I accessed the `__webpack_nonce__` global from within the component, because by the time we bundle it with Webpack, this global reference is lost/minified.

## Approach

By referring to `global.__webpack_nonce__` rather than the bare `__webpack_nonce__`, we tell Webpack that this reference shouldn't change name during bundling.

### Emitted Code

Before this code, for the getNonce() function, after bundling we would emit:

```js
function getNonce() {
    return  true ? __webpack_require__.nc : 0;
}
exports.default = getNonce;
```

And after this PR it looks like:

```js
function getNonce() {
    return typeof __webpack_require__.g.__webpack_nonce__ !== 'undefined' ? __webpack_require__.g.__webpack_nonce__ : null;
}
exports.default = getNonce;
```

## Testing

This wasn't caught by unit tests last time, because it occurs after packaging. 

I failed to test enough last time, so this time I've bundled and loaded this change into my full application, and I can now see it working as intended (Chrome hides the value when it correctly matches the CSP, so this is working perfectly):
![image](https://user-images.githubusercontent.com/97427/154611581-09ec3cde-1bd6-4dc5-a7ae-1f0dab86e43c.png)

Lesson learned, sorry about that!