### PR TITLE
chore(DIST-1493): Add auto label 'new' to issues

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,12 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          default-labels: '["new"]'


### PR DESCRIPTION
## Description

Use a github action to add a new label to issues to allow for automatically closing of other issues later on