### PR TITLE
fix(DIST-1550): Center custom icon in popover button

### DIFF
--- a/packages/embed/src/css/popover.scss
+++ b/packages/embed/src/css/popover.scss
@@ -71,7 +71,7 @@
       justify-content: center;
       align-items: center;
 
-      svg {
+      svg.default {
         margin-top: 6px;
       }
 

--- a/packages/embed/src/factories/create-popover/create-popover.ts
+++ b/packages/embed/src/factories/create-popover/create-popover.ts
@@ -66,7 +66,7 @@ const buildIcon = (customIcon?: string, color?: string) => {
   const triggerIcon = document.createElement('div')
   triggerIcon.className = 'tf-v1-popover-button-icon'
 
-  const svgIcon = `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  const svgIcon = `<svg class="default" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M21 0H0V9L10.5743 24V16.5H21C22.6567 16.5 24 15.1567 24 13.5V3C24 1.34325 22.6567 0 21 0ZM7.5
     9.75C6.672 9.75 6 9.07875 6 8.25C6 7.42125 6.672 6.75 7.5 6.75C8.328 6.75 9 7.42125 9 8.25C9 9.07875 8.328 9.75
     7.5 9.75ZM12.75 9.75C11.922 9.75 11.25 9.07875 11.25 8.25C11.25 7.42125 11.922 6.75 12.75 6.75C13.578 6.75 14.25


### PR DESCRIPTION
Before:
![Screenshot 2022-02-23 at 23 19 00](https://user-images.githubusercontent.com/1561771/155419298-df8718c7-05d2-4d91-bcb0-fe58971fa3f8.png)

After:
![Screenshot 2022-02-23 at 23 19 07](https://user-images.githubusercontent.com/1561771/155419314-1a367c1c-60de-4a78-af86-2ddfa4f891c9.png)

Examples above are using custom icon from [Bootstrap Icons](https://icons.getbootstrap.com/icons/chat-quote-fill/).