### PR TITLE
fix(DIST-1549): Close button color on desktop

### DIFF
--- a/packages/embed/src/css/includes/_close.scss
+++ b/packages/embed/src/css/includes/_close.scss
@@ -1,3 +1,5 @@
+@import 'mobile';
+
 @mixin close() {
   position: absolute;
   font-size: 32px;
@@ -12,5 +14,9 @@
   color: #000;
   &:hover {
     opacity: 1;
+  }
+
+  @include desktop {
+    color: #fff !important;
   }
 }

--- a/packages/embed/src/css/includes/_mobile.scss
+++ b/packages/embed/src/css/includes/_mobile.scss
@@ -5,3 +5,9 @@ $mobile-width: 480px;
     @content;
   }
 }
+
+@mixin desktop {
+  @media (min-width: #{$mobile-width + 1}) {
+    @content;
+  }
+}


### PR DESCRIPTION
Before (desktop, mobile):
![Screenshot 2022-02-23 at 22 49 09](https://user-images.githubusercontent.com/1561771/155424463-76f1946e-021e-4475-9ebb-1d1cd31e1168.png) ![Screenshot 2022-02-23 at 22 51 17](https://user-images.githubusercontent.com/1561771/155424465-4d3bc09e-16c9-4a39-8457-25658140aeae.png)

After (desktop, mobile):
![Screenshot 2022-02-24 at 00 04 25](https://user-images.githubusercontent.com/1561771/155424542-3e013836-953f-4fd2-a9bc-ff84cf2d22b9.png) ![Screenshot 2022-02-24 at 00 04 33](https://user-images.githubusercontent.com/1561771/155424537-265e766b-ba9d-46ec-a6ce-fc144a9f842e.png)

