### PR TITLE
feat(DIST-2005): @typeform/embed-react add the ability to pass custom ref to PopupButton

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -98,6 +98,27 @@ Pass options as props to the component.
 </PopupButton>
 ```
 
+### Passing a custom ref
+
+For some custom use cases it may be convenient to open the pop programmatically (without the button being clicked). 
+
+To do this, pass a ref to the PopupButton component and then use `ref.current.open()` to trigger the popover to open. 
+
+Example: 
+```javascript
+import { emptyEmbed } from "@typeform/embed-react";
+// ...
+const ref = useRef(emptyEmbed)
+const openPopup = () => ref.current.open()
+// ...
+<PopupButton
+  ref={ref}
+  ...
+>
+  click to open
+</PopupButton>
+```
+
 ## What's next?
 
 Learn more about [Vanilla Embed Library](/embed/vanilla). Since React Embed Library is just a React wrapper for Vanilla Embed Library, all concepts apply here as well.

--- a/docs/react.md
+++ b/docs/react.md
@@ -100,7 +100,7 @@ Pass options as props to the component.
 
 ### Passing a custom ref
 
-For some custom use cases it may be convenient to open the pop programmatically (without the button being clicked). 
+For some custom use cases it may be convenient to open the popup programmatically (without the button being clicked). 
 
 To do this, pass a ref to the PopupButton component and then use `ref.current.open()` to trigger the popup to open. 
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -102,7 +102,7 @@ Pass options as props to the component.
 
 For some custom use cases it may be convenient to open the pop programmatically (without the button being clicked). 
 
-To do this, pass a ref to the PopupButton component and then use `ref.current.open()` to trigger the popover to open. 
+To do this, pass a ref to the PopupButton component and then use `ref.current.open()` to trigger the popup to open. 
 
 Example: 
 ```javascript

--- a/packages/embed-react/src/components/make-button-component.tsx
+++ b/packages/embed-react/src/components/make-button-component.tsx
@@ -18,6 +18,7 @@ type ButtonComponentBaseProps = {
   style?: CSSProperties
   className?: string
   children: ReactNode
+  ref?: MutableRefObject<GenericEmbed>
 }
 
 type ButtonComponentProps<T> = T & ButtonComponentBaseProps
@@ -26,12 +27,12 @@ type CreateFnProps<T> = Omit<ButtonComponentProps<T>, keyof ButtonComponentBaseP
 
 type CreateFn<T> = (id: string, props: CreateFnProps<T>) => GenericEmbed
 
-type GenericEmbed = {
+export type GenericEmbed = {
   unmount: () => void
   open: () => void
 }
 
-const emptyEmbed: GenericEmbed = {
+export const emptyEmbed: GenericEmbed = {
   unmount: () => {},
   open: () => {},
 }
@@ -44,15 +45,18 @@ function makeButtonComponent<T>(createFn: CreateFn<T>, cssFilename: string) {
     style = {},
     className = '',
     buttonProps,
+    ref: refOverride,
     ...props
   }: ButtonComponentProps<T>) => {
-    const ref: MutableRefObject<GenericEmbed> = useRef(emptyEmbed)
+    const internalRef: MutableRefObject<GenericEmbed> = useRef(emptyEmbed)
+    const ref = refOverride || internalRef
+
     useEffect(() => {
       ref.current = createFn(id, props)
       return () => ref.current.unmount()
-    }, [id, props])
+    }, [id, props, ref])
 
-    const handleClick = useMemo(() => () => ref.current.open(), [])
+    const handleClick = useMemo(() => () => ref.current.open(), [ref])
 
     const triggerElement = React.createElement(as, {
       style,


### PR DESCRIPTION
Let me know if this is already possible with the react package and I am blind. 

But I have a use-case where there I need more than just the button click to open the popover. 

I didn't want to go too deep and create a popover with state that can be passed in (no-button), and instead wanted to keep a refactor recommendation minimal by just allowing a ref override on the existing component.

First PR here, so please let me know if there is anything else that I can provide!