### PR TITLE
fix(DIST-2005): Use React.forwardRef to pass ref

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -100,20 +100,19 @@ Pass options as props to the component.
 
 ### Passing a custom ref
 
-For some custom use cases it may be convenient to open the popup programmatically (without the button being clicked). 
+For some custom use cases it may be convenient to open the popup programmatically (without the button being clicked).
 
-To do this, pass a ref to the PopupButton component and then use `ref.current.open()` to trigger the popup to open. 
+To do this, pass a ref to the PopupButton component and then use `ref.current.open()` to trigger the popup to open.
 
-Example: 
+Example:
+
 ```javascript
-import { emptyEmbed } from "@typeform/embed-react";
-// ...
-const ref = useRef(emptyEmbed)
-const openPopup = () => ref.current.open()
+const ref = useRef()
+const openPopup = () => ref.current?.open()
 // ...
 <PopupButton
+  id="<form-id>"
   ref={ref}
-  ...
 >
   click to open
 </PopupButton>
@@ -124,9 +123,9 @@ const openPopup = () => ref.current.open()
 Learn more about [Vanilla Embed Library](/embed/vanilla). Since React Embed Library is just a React wrapper for Vanilla Embed Library, all concepts apply here as well.
 
 You can:
+
 - embed typeform [inline in page](/embed/inline)
 - open it [in modal window](/embed/modal)
 - see all available [configuration options](/embed/configuration)
 
 If you want to create a form so you can embed it, sign up for a [Typeform](https://typeform.com) account or head to our documentation for the [Create API](/create/).
-

--- a/packages/demo-nextjs/pages/_app.js
+++ b/packages/demo-nextjs/pages/_app.js
@@ -19,6 +19,7 @@ function MyApp({ Component, pageProps }) {
     '/sidetab': 'sidetab',
     '/popover': 'popover',
     '/vanilla': 'vanilla library in react',
+    '/forward-ref': 'forward ref',
   }
 
   return (

--- a/packages/demo-nextjs/pages/forward-ref.js
+++ b/packages/demo-nextjs/pages/forward-ref.js
@@ -1,0 +1,54 @@
+import { useRef } from 'react'
+import Head from 'next/head'
+import PropTypes from 'prop-types'
+import { PopupButton } from '@typeform/embed-react'
+
+import Sparkle from '../components/sparkle'
+
+export default function PopupPage({ id }) {
+  const buttonStyle = {
+    padding: '10px 20px',
+    borderRadius: 10,
+    border: 'none',
+    background: 'navy',
+    color: 'white',
+    fontSize: 16,
+    cursor: 'pointer',
+  }
+  const ref = useRef()
+
+  return (
+    <div>
+      <Head>
+        <title>Create Next App</title>
+      </Head>
+
+      <main>
+        <h1>
+          This is an example <a href="https://nextjs.org">Next.js</a> app.
+        </h1>
+
+        <p>
+          Embed popup with forwarded ref &lt;3 Next.js <Sparkle />
+        </p>
+
+        <p>
+          <PopupButton id={id} ref={ref} style={buttonStyle} size={66} medium="demo-test">
+            <span role="img" aria-label="check">
+              ️✅
+            </span>
+            <span style={{ marginLeft: 10 }}>open popup</span>
+          </PopupButton>
+        </p>
+
+        <p>
+          <button onClick={() => ref.current.open()}>click here to open the popup via ref</button>
+        </p>
+      </main>
+    </div>
+  )
+}
+
+PopupPage.propTypes = {
+  id: PropTypes.string,
+}

--- a/packages/embed-react/src/components/make-button-component.tsx
+++ b/packages/embed-react/src/components/make-button-component.tsx
@@ -18,7 +18,6 @@ type ButtonComponentBaseProps = {
   style?: CSSProperties
   className?: string
   children: ReactNode
-  ref?: MutableRefObject<GenericEmbed>
 }
 
 type ButtonComponentProps<T> = T & ButtonComponentBaseProps
@@ -38,17 +37,11 @@ export const emptyEmbed: GenericEmbed = {
 }
 
 function makeButtonComponent<T>(createFn: CreateFn<T>, cssFilename: string) {
-  return ({
-    id,
-    children,
-    as = 'button',
-    style = {},
-    className = '',
-    buttonProps,
-    ref: refOverride,
-    ...props
-  }: ButtonComponentProps<T>) => {
-    const internalRef: MutableRefObject<GenericEmbed> = useRef(emptyEmbed)
+  const Button = (
+    { id, children, as = 'button', style = {}, className = '', buttonProps, ...props }: ButtonComponentProps<T>,
+    refOverride: MutableRefObject<GenericEmbed> | any
+  ) => {
+    const internalRef = useRef(emptyEmbed)
     const ref = refOverride || internalRef
 
     useEffect(() => {
@@ -74,6 +67,8 @@ function makeButtonComponent<T>(createFn: CreateFn<T>, cssFilename: string) {
       </>
     )
   }
+
+  return React.forwardRef(Button)
 }
 
 export { makeButtonComponent }


### PR DESCRIPTION
Fix for https://github.com/Typeform/embed/pull/546

@vandercloak were you able to pass `ref` to your button? I received a report it is not working and noticed we missed `React.forwardRef`.