### PR TITLE
feat(INT-4274): Send clientId for gtag

### DIFF
--- a/packages/embed/src/utils/setup-google-analytics-instance.spec.ts
+++ b/packages/embed/src/utils/setup-google-analytics-instance.spec.ts
@@ -54,7 +54,6 @@ describe('setup-google-analytics-instance', () => {
           makeTracker('UA-tracking-3', 'one.more.client.identifier'),
         ]),
     }
-    window['GoogleAnalyticsObject'] = 'ga'
     window['ga'] = GoogleAnalyticsObjectMock
 
     it('uses first GA tracker', () => {
@@ -73,6 +72,24 @@ describe('setup-google-analytics-instance', () => {
         embedId: 'embed-id-value',
         gaClientId: 'different.client.identifier',
       })
+    })
+
+    it('sends gaMessage when gtag exists', () => {
+      window['gtag'] = jest.fn().mockImplementation((_: string, __: string, ___: string, callback: Function) => {
+        callback('different.client.identifier')
+      })
+      setupGaInstance(iframeMock, 'embed-id-value', 'UA-tracking-2')
+      jest.runAllTimers()
+      expect(iframePostMessageSpy).toHaveBeenCalledWith(
+        {
+          data: {
+            embedId: 'embed-id-value',
+            gaClientId: 'different.client.identifier',
+          },
+          type: 'ga-client-id',
+        },
+        '*'
+      )
     })
   })
 })

--- a/packages/embed/src/utils/setup-google-analytics-instance.ts
+++ b/packages/embed/src/utils/setup-google-analytics-instance.ts
@@ -45,7 +45,6 @@ export const setupGaInstance = (iframe: HTMLIFrameElement, embedId: string, shar
     })
   } else if (window.ga) {
     try {
-
       const gaObject: GoogleAnalyticsObject = window.ga
       const tracker = getTracker(gaObject.getAll(), trackingId)
 
@@ -53,17 +52,19 @@ export const setupGaInstance = (iframe: HTMLIFrameElement, embedId: string, shar
         sendGaIdMessage(embedId, tracker.get('clientId'), iframe)
       } else {
         logError(
-          `Whoops! You enabled the shareGaInstance feature in your typeform embed but the tracker with ID ${trackingId} was not found. ` +
-          'Make sure to include Google Analytics Javascript code before the Typeform Embed Javascript code in your page and use correct tracker ID. '
+          `Whoops! You enabled the shareGaInstance feature in your` +
+            `typeform embed but the tracker with ID ${trackingId} was not found. ` +
+            'Make sure to include Google Analytics Javascript code before the Typeform Embed Javascript' +
+            'code in your page and use correct tracker ID. '
         )
       }
     } catch (exception) {
       logError(
-        'Whoops! You enabled the shareGaInstance feature in your typeform embed but the Google Analytics object has not been found. ' +
-        'Make sure to include Google Analytics Javascript code before the Typeform Embed Javascript code in your page. '
+        'Whoops! You enabled the shareGaInstance feature in your typeform embed but the Google Analytics ' +
+          'object has not been found. Make sure to include Google Analytics Javascript code before the ' +
+          'Typeform Embed Javascript code in your page. '
       )
       logError(exception)
     }
   }
 }
-


### PR DESCRIPTION
## Description

- JIRA issue: [INT-4274](https://typeform.atlassian.net/browse/INT-4274)

On [INT-3774](https://typeform.atlassian.net/browse/INT-3774) we added the new gtag snippet to Louvre. 
⚠️ the old ga analytics.js will be discontinued on July

On this PT we added gtag support in order to send the client_id to louvre.
This is kind of unrelated to the migration itself, but if the users add a gtag script instead of ga, we can now support it.

To test it I used this html with an embed, that uses the gtag google script:

[embed-g4a-si.html.zip](https://github.com/Typeform/embed/files/10519526/embed-g4a-si.html.zip)

[INT-4274]: https://typeform.atlassian.net/browse/INT-4274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-3774]: https://typeform.atlassian.net/browse/INT-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ