### PR TITLE
fix(TYP-8260): Prevent undefined trackingId

### DIFF
--- a/packages/embed/src/utils/setup-google-analytics-instance.ts
+++ b/packages/embed/src/utils/setup-google-analytics-instance.ts
@@ -53,6 +53,12 @@ export const setupGaInstance = (iframe: HTMLIFrameElement, embedId: string, shar
       trackingId = getTrackingFromDataLayer()
     }
     if (!trackingId) {
+      logError(
+        'Whoops! You enabled the shareGaInstance feature in your' +
+          'typeform embed but the tracker ID could not be retrieved. ' +
+          'Make sure to include Google Analytics Javascript code before the Typeform Embed Javascript' +
+          'code in your page and use correct tracker ID. '
+      )
       return
     }
     let fetchedAccountId = false


### PR DESCRIPTION
While fixing TYP-8260 noticed that sometimes we do not receive the trackingId directly.
With @mathio we discussed the possibility of reading it from dataLayer.

This PR addresses that issue, by iterating on dataLayer and fetching the trackingId in 'config'