### PR TITLE
fix(REACH-363): Update typo in docs on hidden fields

### DIFF
--- a/docs/hidden-fields.md
+++ b/docs/hidden-fields.md
@@ -6,13 +6,13 @@ nav_order: 14
 
 # Use Hidden Fields in embedded typeforms
 
-You can [Hidden Fields](https://help.typeform.com/hc/en-us/articles/360050448072-Hidden-fields-explained) to pass information to a typeform embedded on your site.
+You can use [Hidden Fields](https://help.typeform.com/hc/en-us/articles/360050448072-Hidden-fields-explained) to pass information to a typeform embedded on your site.
 
------
+---
 
 **NOTE:** You are responsible for any information you share with Hidden Fields. Recording and transmitting identifying information, like email addresses, is prohibited by some services (like Google Analytics). Make sure that the way you use Hidden Fields stays within the laws of your country and the terms and conditions of any service you are using with Typeform.
 
------
+---
 
 Hidden Fields are key-value pairs of information you already know about your respondents. You can use the information you already know about respondents to customize your typeform — for example, to greet respondents by name or ask certain questions for respondents in a specific age group. Or, you can tie the information you already know with the new data you collect in the typeform — for example, to gather more information about an individual respondent.
 
@@ -23,49 +23,47 @@ Values for Hidden Fields come from the parameters you add to your typeform's URL
 When you embed a typeform you need pass hidden fields into the embed itself. It will take care of passing the values correctly in typeform URL.
 
 In JavaScript:
+
 ```javascript
 import { createWidget } from '@typeform/embed'
 import '@typeform/embed/build/css/widget.css'
 
-createWidget("moe6aa", {
-  container: document.getElementById("wrapper"),
+createWidget('<form-id>', {
+  container: document.getElementById('wrapper'),
   hidden: {
-    full_name: "John Doe",
-    email: "john@example.com"
+    full_name: 'John Doe',
+    email: 'john@example.com',
   },
 })
 ```
 
 Or via HTML:
+
 ```html
-<div
-  data-tf-widget="<form-id>"
-  data-tf-hidden="full_name=John Doe,email=john@example.com"
-></div>
+<div data-tf-widget="<form-id>" data-tf-hidden="full_name=John Doe,email=john@example.com"></div>
 <script src="//embed.typeform.com/next/embed.js"></script>
 ```
 
 ## Pass values from host page URL
 
-You can also configure the embed to read hidden field values from the host page query parameters. 
+You can also configure the embed to read hidden field values from the host page query parameters.
 
 In JavaScript:
+
 ```javascript
 import { createWidget } from '@typeform/embed'
 import '@typeform/embed/build/css/widget.css'
 
-createWidget("moe6aa", {
-  container: document.getElementById("wrapper"),
-  transitiveSearchParams: ["full_name", "email"],
+createWidget('<form-id>', {
+  container: document.getElementById('wrapper'),
+  transitiveSearchParams: ['full_name', 'email'],
 })
 ```
 
 Or via HTML:
+
 ```html
-<div
-  data-tf-widget="<form-id>"
-  data-tf-transitive-search-params="full_name,email"
-></div>
+<div data-tf-widget="<form-id>" data-tf-transitive-search-params="full_name,email"></div>
 <script src="//embed.typeform.com/next/embed.js"></script>
 ```
 
@@ -77,10 +75,8 @@ https://example.com/embed.html?full_name=John%20Doe&email=john%40example.com&age
 
 The embed will pass hidden fields `full_name` and `email` to the typeform. Query param `age` will be ignored.
 
-
 ## What's next?
 
 Read more about [how to pass callbacks](/embed/callbacks).
 
 Or check out what other open-source developers have created on the [Community projects](/community/) page.
-

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "postinstall": "yarn lerna bootstrap",
     "clean": "yarn lerna run clean",
     "build": "yarn lerna run build",
-    "lint": "yarn lerna run lint",
+    "lint": "yarn lerna run lint && yarn docs-prettier-check",
     "test": "yarn lerna run test",
     "test:functional": "yarn lerna run test:functional",
     "test:visual": "yarn lerna run test:visual",
     "release": "sh ./scripts/release.sh",
-    "release:preview": "yarn lerna run release:preview"
+    "release:preview": "yarn lerna run release:preview",
+    "docs-prettier-check": "prettier --check ./docs --ignore-path .eslintignore",
+    "docs-prettier": "prettier --write ./docs --ignore-path .eslintignore"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Format docs with prettier. Add yarn command to run prettier also on docs.

*Note:* The source diff seems a bit weird, use rich diff to view changes.