### PR TITLE
fix(WEB-6512): Update docs link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ To create your own typeforms to embed, you need a Typeform account. Head to [www
 ## Limitations
 
 For security purposes we prevent embedding typeorms in unsecure pages (via [CSP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)).
-You can embed your typeform on pages served over HTTPS or via HTTP on localhost. You can also [embed in wrapped progressive web apps](https://developer.typeform.com/embed/native-mobile-apps/).
+You can embed your typeform on pages served over HTTPS or via HTTP on localhost. You can also [embed in wrapped progressive web apps](https://www.typeform.com/developers/embed/mobile-apps/#progressive-web-apps).
 
 ## Supported browsers
 


### PR DESCRIPTION
WEB-6512

Update a link in the docs. We're no-more using the domain `developers.typeform.com`, for SEO reasons we wanna keep everything under `typeform.com`. The changed link was pointing to an outdated version of the developer portal and weirdly wasn't getting redirected to `typeform.com/developers`.

***Old version***

![image](https://github.com/Typeform/embed/assets/28822870/410c0265-8f42-4275-813b-f16fb7a50c1b)


*** New version***

![image](https://github.com/Typeform/embed/assets/28822870/6559fdf1-69cf-4b8f-929b-ccf94c7c4a94)
