### PR TITLE
fix(REACH-573): Update types of payloads for callbacks

### DIFF
--- a/packages/demo-html/public/callbacks.html
+++ b/packages/demo-html/public/callbacks.html
@@ -65,9 +65,9 @@
         console.log('modal window closed', data)
       }
 
-      function onTypeformEndingButtonClick() {
+      function onTypeformEndingButtonClick(data) {
         alert('onEndingButtonClick')
-        console.log('button on ending screen clicked')
+        console.log('button on ending screen clicked', data)
       }
     </script>
   </body>

--- a/packages/embed/src/base/actionable-options.ts
+++ b/packages/embed/src/base/actionable-options.ts
@@ -1,34 +1,54 @@
+interface WithResponseId {
+  responseId: string
+}
+
+interface WithFormId {
+  formId: string
+}
+
+interface WithRef {
+  ref: string
+}
+
+interface WithHeight {
+  height: number
+}
+
 export type ActionableOptions = {
   /**
    * Callback function that will be executed once the typeform is ready.
    */
-  onReady?: () => void
+  onReady?: (event: WithFormId) => void
   /**
    * Callback function that will be executed right after the typeform is successfully submitted.
-   * @param {Object} payload - Event payload.
-   * @param {string} payload.responseId - Response ID string.
-   * @param {string} response_id - DEPRECATED.
+   * @param {Object} event - Event payload.
+   * @param {string} event.formId - Form ID string.
+   * @param {string} event.responseId - Response ID string.
    */
-  onSubmit?: (payload: { responseId: string }) => void
+  onSubmit?: (event: WithFormId & WithResponseId) => void
   /**
    * Callback function that will be executed once the typeform's active screen changes.
    * @param {Object} event - Event payload.
+   * @param {string} event.formId - Form ID string.
    * @param {string} event.ref - New question ref.
    */
-  onQuestionChanged?: (event: { ref: string }) => void
+  onQuestionChanged?: (event: WithFormId & WithRef) => void
   /**
    * Callback function that will be executed once the typeform's active screen height changes.
    * @param {Object} event - Event payload.
+   * @param {string} event.formId - Form ID string.
    * @param {string} event.ref - New question ref.
    * @param {number} event.height - New question height.
    */
-  onHeightChanged?: (event: { ref: string; height: number }) => void
+  onHeightChanged?: (event: WithFormId & WithRef & WithHeight) => void
   /**
    * Callback function that will be executed once the Iframe close button is clicked.
    */
   onClose?: () => void
   /**
    * Callback function when button on ending screen is clicked.
+   * @param {Object} event - Event payload.
+   * @param {string} event.formId - Form ID string.
    */
-  onEndingButtonClick?: () => void
+  onEndingButtonClick?: (event: WithFormId) => void
 }


### PR DESCRIPTION
Match types defined in this lib with actual payload sent by the embedded form.

Resolves #577.