### PR TITLE
feat(REACH-576): Add `ref` to the `onEndingButtonClick` payload type

### DIFF
--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -233,8 +233,11 @@ You can listen to form events by providing callback methods:
     onClose: ({ formId }) => {
       console.log(`Modal window with form ${formId} was closed`)
     }
-    onEndingButtonClick: ({ formId }) => {
+    onEndingButtonClick: ({ formId, ref }) => {
       console.log(`Ending button clicked in form ${formId}`)
+
+      // for plans with "Redirect from ending screen" feature you also receive `ref`:
+      console.log(`Ending button clicked in end screen ${ref}`)
     }
   })
   document.querySelector('#btn').click = () => {
@@ -261,6 +264,7 @@ Callback method receive payload object from the form. Each payload contains form
   - no payload
 - onEndingButtonClick
   - `formId` (string)
+  - `ref` (string) identifies the end screen (_Note:_ this is available for plans with "Redirect from ending screen" feature only.)
 
 See [callbacks example in demo package](../../packages/demo-html/public/callbacks.html).
 

--- a/packages/embed/src/base/actionable-options.ts
+++ b/packages/embed/src/base/actionable-options.ts
@@ -49,6 +49,7 @@ export type ActionableOptions = {
    * Callback function when button on ending screen is clicked.
    * @param {Object} event - Event payload.
    * @param {string} event.formId - Form ID string.
+   * @param {string} event.ref - End screen ref string (for plans with "Redirect from ending screen" feature).
    */
-  onEndingButtonClick?: (event: WithFormId) => void
+  onEndingButtonClick?: (event: WithFormId & Partial<WithRef>) => void
 }


### PR DESCRIPTION
For plans with "Redirect from ending screen" feature (currently plans Plus and above) the `onEndingButtonClick` callback also receives `ref` along with `formId`. The `ref` identifies the end screen where the button was clicked.

Resolves #584 