### PR TITLE
fix(REACH-644): Update close button CSS

### DIFF
--- a/packages/embed/src/css/includes/_close.scss
+++ b/packages/embed/src/css/includes/_close.scss
@@ -1,12 +1,17 @@
 @import 'mobile';
 
 @mixin close($top: 6px, $right: 8px) {
+  display: block;
+  padding: 0;
+  margin: 0;
   position: absolute;
   font-size: 32px;
+  font-weight: normal;
   line-height: 24px;
   width: 24px;
   height: 24px;
   text-align: center;
+  text-transform: none;
   cursor: pointer;
   opacity: 0.75;
   transition: opacity 0.25s ease-in-out;
@@ -16,6 +21,7 @@
   right: $right;
   background: none;
   border: none;
+  border-radius: 0;
 
   &:hover {
     opacity: 1;


### PR DESCRIPTION
Update CSS to avoid possible conflicts with other general CSS styles of a <button>.

There was a conflict with some WP themes:
| before | after|
|--|--|
| ![Screenshot 2023-07-21 at 11 03 06](https://github.com/Typeform/embed/assets/1561771/a017f7b0-bfec-4ba0-9028-1bc72a862fc7) | ![Screenshot 2023-07-21 at 11 02 36](https://github.com/Typeform/embed/assets/1561771/24750fe8-8331-4f27-8bc6-34c449f44696) |
