### PR TITLE
feat(REACH-800): Update CI to run on Node version 20

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 14 # end of life 2023-04-30
           - 16 # end of life 2023-09-11
           - 18 # end of life 2025-04-30
+          - 20 # end of life 2025-04-30
     name: build-lint-test - node ${{ matrix.node_version }}
     steps:
       - name: Check out Git repository
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Get yarn cache
         uses: actions/cache@v2
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Get yarn cache
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Get yarn cache
         uses: actions/cache@v3

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Get yarn cache
         uses: actions/cache@v2

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -349,7 +349,7 @@ You can find examples for specific use-cases in our demos:
 
 Requirements:
 
-- node >= 14 (for node v12 use [v1.38.0](https://www.npmjs.com/package/@typeform/embed/v/1.38.0))
+- node >= 16
 - yarn
 
 Install dependencies:

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -42,7 +42,7 @@
     "coverage": "jest --coverage",
     "cy:open": "yarn cypress open",
     "cy:open:vrt": "yarn cypress open --env testType=visual",
-    "cy:open:func": "yarn cy:open -c integrationFolder=./e2e/spec/functional/",
+    "cy:open:func": "yarn cy:open -c e2e.specPattern=./e2e/spec/functional/",
     "cy:functional": "yarn cypress run --spec e2e/spec/functional/**/* --headless",
     "cy:visual": "yarn cypress run --spec e2e/spec/visual/**/* --env testType=visual",
     "test:functional": "start-server-and-test demo 9090 cy:functional",


### PR DESCRIPTION
BREAKING CHANGE: The library no longer supports node version 14 (end of life 2023-04-30). While we officially do not support it anymore, there are no known issues at the moment and the library should work with this node version so far.