### PR TITLE
feat(REACH-897): Support hidden fields in live embed codes

### DIFF
--- a/packages/demo-html/public/live-embed.html
+++ b/packages/demo-html/public/live-embed.html
@@ -27,7 +27,7 @@
   </head>
   <body>
     <div class="element">I have z-index 10k</div>
-    <div id="wrapper" data-tf-live="embed-id"></div>
+    <div id="wrapper" data-tf-live="embed-id" data-tf-hidden="email=foo@bar.com"></div>
     <script src="./lib/embed.js"></script>
   </body>
 </html>

--- a/packages/embed/e2e/spec/functional/live-embed.cy.ts
+++ b/packages/embed/e2e/spec/functional/live-embed.cy.ts
@@ -23,5 +23,9 @@ describe('Single Embed Code', () => {
       cy.get('.tf-v1-widget iframe').should('be.visible')
       cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', 'form.typeform.com/to/')
     })
+
+    it('should pass hidden fields as hash', () => {
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', '#foo=foo+value&email=foo%40bar.com')
+    })
   })
 })

--- a/packages/embed/src/browser.ts
+++ b/packages/embed/src/browser.ts
@@ -10,18 +10,21 @@ import {
 import * as lib from './index'
 
 function loadEmbedElements(forceReload: boolean = false) {
-  initializeEmbedElements(forceReload)
-  initializeLiveEmbeds(forceReload).then(() => {
-    initializeEmbedElements(forceReload)
+  initializeEmbedElements({ forceReload })
+  initializeLiveEmbeds({
+    forceReload,
+    onLiveEmbedLoad: (container) => {
+      initializeEmbedElements({ container, forceReload })
+    },
   })
 }
 
-function initializeEmbedElements(forceReload: boolean) {
-  initializePopovers(forceReload)
-  initializePopups(forceReload)
-  initializeSidetabs(forceReload)
-  initializeSliders(forceReload)
-  initializeWidgets(forceReload)
+function initializeEmbedElements(initProps: { container?: HTMLElement; forceReload: boolean }) {
+  initializePopovers(initProps)
+  initializePopups(initProps)
+  initializeSidetabs(initProps)
+  initializeSliders(initProps)
+  initializeWidgets(initProps)
 }
 
 const reload = () => loadEmbedElements(true)

--- a/packages/embed/src/initializers/initialize-live-embeds.ts
+++ b/packages/embed/src/initializers/initialize-live-embeds.ts
@@ -1,7 +1,13 @@
 import { LIVE_EMBED_ATTRIBUTE } from '../constants'
 import { fetchLiveEmbed } from '../live-embed/fetch-live-embed'
 
-export const initializeLiveEmbeds = async (forceReload: boolean) => {
+export const initializeLiveEmbeds = ({
+  forceReload,
+  onLiveEmbedLoad,
+}: {
+  forceReload: boolean
+  onLiveEmbedLoad: (element: HTMLElement) => void
+}) => {
   const embedTypeElements = document.querySelectorAll<HTMLElement>(`[${LIVE_EMBED_ATTRIBUTE}]`)
 
   for (let index = 0; index < embedTypeElements.length; index += 1) {
@@ -12,9 +18,12 @@ export const initializeLiveEmbeds = async (forceReload: boolean) => {
         throw new Error(`Invalid ${LIVE_EMBED_ATTRIBUTE}=${embedId} for embed #${index}`)
       }
 
-      const { html } = await fetchLiveEmbed(embedId)
-      element.innerHTML = html
-      element.dataset.tfLoaded = 'true'
+      fetchLiveEmbed(embedId).then(({ html }) => {
+        element.innerHTML = html
+        element.dataset.tfLoaded = 'true'
+
+        onLiveEmbedLoad(element)
+      })
     }
   }
 }

--- a/packages/embed/src/initializers/initialize-popovers.ts
+++ b/packages/embed/src/initializers/initialize-popovers.ts
@@ -3,9 +3,21 @@ import { POPOVER_ATTRIBUTE } from '../constants'
 
 import { initialize } from './initialize'
 
-export const initializePopovers = (forceReload: boolean = false) => {
-  initialize(POPOVER_ATTRIBUTE, 'popover.css', forceReload, (formId, options, button) => {
-    const { toggle } = createPopover(formId, options as PopoverOptions)
-    button.onclick = toggle
+export const initializePopovers = ({
+  container,
+  forceReload = false,
+}: {
+  container?: HTMLElement
+  forceReload?: boolean
+}) => {
+  initialize({
+    embedElementAttribute: POPOVER_ATTRIBUTE,
+    cssFilename: 'popover.css',
+    container,
+    forceReload,
+    factoryMethod: (formId, options, button) => {
+      const { toggle } = createPopover(formId, options as PopoverOptions)
+      button.onclick = toggle
+    },
   })
 }

--- a/packages/embed/src/initializers/initialize-popups.ts
+++ b/packages/embed/src/initializers/initialize-popups.ts
@@ -4,9 +4,21 @@ import { invokeWithoutDefault } from '../utils'
 
 import { initialize } from './initialize'
 
-export const initializePopups = (forceReload: boolean = false) => {
-  initialize(POPUP_ATTRIBUTE, 'popup.css', forceReload, (formId, options, button) => {
-    const { toggle } = createPopup(formId, options as PopupOptions)
-    button.onclick = invokeWithoutDefault(toggle)
+export const initializePopups = ({
+  container,
+  forceReload = false,
+}: {
+  container?: HTMLElement
+  forceReload?: boolean
+}) => {
+  initialize({
+    embedElementAttribute: POPUP_ATTRIBUTE,
+    cssFilename: 'popup.css',
+    container,
+    forceReload,
+    factoryMethod: (formId, options, button) => {
+      const { toggle } = createPopup(formId, options as PopupOptions)
+      button.onclick = invokeWithoutDefault(toggle)
+    },
   })
 }

--- a/packages/embed/src/initializers/initialize-sidetabs.ts
+++ b/packages/embed/src/initializers/initialize-sidetabs.ts
@@ -3,8 +3,20 @@ import { SIDETAB_ATTRIBUTE } from '../constants'
 
 import { initialize } from './initialize'
 
-export const initializeSidetabs = (forceReload: boolean = false) => {
-  initialize(SIDETAB_ATTRIBUTE, 'sidetab.css', forceReload, (formId, options) => {
-    createSidetab(formId, options as SidetabOptions)
+export const initializeSidetabs = ({
+  container,
+  forceReload = false,
+}: {
+  container?: HTMLElement
+  forceReload?: boolean
+}) => {
+  initialize({
+    embedElementAttribute: SIDETAB_ATTRIBUTE,
+    cssFilename: 'sidetab.css',
+    container,
+    forceReload,
+    factoryMethod: (formId, options) => {
+      createSidetab(formId, options as SidetabOptions)
+    },
   })
 }

--- a/packages/embed/src/initializers/initialize-sliders.ts
+++ b/packages/embed/src/initializers/initialize-sliders.ts
@@ -4,9 +4,21 @@ import { invokeWithoutDefault } from '../utils'
 
 import { initialize } from './initialize'
 
-export const initializeSliders = (forceReload: boolean = false) => {
-  initialize(SLIDER_ATTRIBUTE, 'slider.css', forceReload, (formId, options, button) => {
-    const { toggle } = createSlider(formId, options as SliderOptions)
-    button.onclick = invokeWithoutDefault(toggle)
+export const initializeSliders = ({
+  container,
+  forceReload = false,
+}: {
+  container?: HTMLElement
+  forceReload?: boolean
+}) => {
+  initialize({
+    embedElementAttribute: SLIDER_ATTRIBUTE,
+    cssFilename: 'slider.css',
+    container,
+    forceReload,
+    factoryMethod: (formId, options, button) => {
+      const { toggle } = createSlider(formId, options as SliderOptions)
+      button.onclick = invokeWithoutDefault(toggle)
+    },
   })
 }

--- a/packages/embed/src/initializers/initialize-widgets.ts
+++ b/packages/embed/src/initializers/initialize-widgets.ts
@@ -3,8 +3,20 @@ import { WIDGET_ATTRIBUTE } from '../constants'
 
 import { initialize } from './initialize'
 
-export const initializeWidgets = (forceReload: boolean = false) => {
-  initialize(WIDGET_ATTRIBUTE, 'widget.css', forceReload, (formId, options, container) => {
-    createWidget(formId, { ...(options as WidgetOptions), container })
+export const initializeWidgets = ({
+  container,
+  forceReload = false,
+}: {
+  container?: HTMLElement
+  forceReload?: boolean
+}) => {
+  initialize({
+    embedElementAttribute: WIDGET_ATTRIBUTE,
+    cssFilename: 'widget.css',
+    container,
+    forceReload,
+    factoryMethod: (formId, options, container) => {
+      createWidget(formId, { ...(options as WidgetOptions), container })
+    },
   })
 }

--- a/packages/embed/src/initializers/initialize.ts
+++ b/packages/embed/src/initializers/initialize.ts
@@ -1,14 +1,22 @@
 import { includeCss, waitForHubspotCookie } from '../utils'
 
 import { buildOptionsFromAttributes } from './build-options-from-attributes'
+import { mergeOptions } from './merge-options'
 
-export const initialize = async (
-  embedElementAttribute: string,
-  cssFilename: string,
-  forceReload: boolean = false,
+export const initialize = async ({
+  embedElementAttribute,
+  cssFilename,
+  forceReload = false,
+  factoryMethod,
+  container = document,
+}: {
+  embedElementAttribute: string
+  cssFilename: string
+  forceReload?: boolean
   factoryMethod: (id: string, options: unknown, element: HTMLElement) => void
-) => {
-  const embedTypeElements = document.querySelectorAll<HTMLElement>(`[${embedElementAttribute}]`)
+  container?: HTMLElement | Document
+}) => {
+  const embedTypeElements = container.querySelectorAll<HTMLElement>(`[${embedElementAttribute}]`)
 
   if (embedTypeElements.length > 0) {
     includeCss(cssFilename)
@@ -16,15 +24,23 @@ export const initialize = async (
 
   for (let index = 0; index < embedTypeElements.length; index += 1) {
     const element = embedTypeElements.item(index)
+
     if (forceReload || element.dataset.tfLoaded !== 'true') {
       const formId = element.getAttribute(embedElementAttribute)
       if (!formId) {
         throw new Error(`Invalid ${embedElementAttribute}=${formId} for embed #${index}`)
       }
+
       if (element.hasAttribute('data-tf-hubspot')) {
         await waitForHubspotCookie()
       }
-      factoryMethod(formId, buildOptionsFromAttributes(element), element)
+
+      const options = mergeOptions(
+        buildOptionsFromAttributes(element),
+        container === document ? {} : buildOptionsFromAttributes(container as HTMLElement)
+      )
+
+      factoryMethod(formId, options, element)
       element.dataset.tfLoaded = 'true'
     }
   }

--- a/packages/embed/src/initializers/merge-options.spec.ts
+++ b/packages/embed/src/initializers/merge-options.spec.ts
@@ -1,0 +1,39 @@
+import { mergeOptions } from './merge-options'
+
+describe('merge-options', () => {
+  describe('#mergeOptions', () => {
+    it('should merge options', () => {
+      const optionsA = {
+        a: true,
+        b: {
+          b1: 'foo',
+          b2: 'bar',
+        },
+        c: 'foo',
+        d: 42,
+      }
+
+      const optionsB = {
+        b: {
+          b2: 'baz',
+          b3: 'new',
+        },
+        c: false,
+        d: undefined,
+        e: 'foo',
+      }
+
+      expect(mergeOptions(optionsA, optionsB)).toEqual({
+        a: true,
+        b: {
+          b1: 'foo',
+          b2: 'baz',
+          b3: 'new',
+        },
+        c: false,
+        d: 42,
+        e: 'foo',
+      })
+    })
+  })
+})

--- a/packages/embed/src/initializers/merge-options.ts
+++ b/packages/embed/src/initializers/merge-options.ts
@@ -1,0 +1,18 @@
+export const mergeOptions = (
+  ...args: Array<Record<string, undefined | string | boolean | number | Record<string, unknown>>>
+) =>
+  args.reduce((options, slice) => {
+    Object.entries(slice).forEach(([key, value]) => {
+      if (value === undefined) {
+        return options
+      }
+
+      if (typeof options[key] === 'object' && typeof value === 'object') {
+        options[key] = { ...(options[key] as object), ...value }
+      } else {
+        options[key] = value
+      }
+    })
+
+    return options
+  }, {})


### PR DESCRIPTION
Support hidden fields in embeds loaded with the `data-tf-live` attribute. Any property passed to that element (e.g. `data-tf-hidden` will overwrite the options saved in the live embed code.