### PR TITLE
fix(REACH-914): wrong overlapping settings in live embed

### DIFF
--- a/packages/embed/e2e/spec/functional/live-embed.cy.ts
+++ b/packages/embed/e2e/spec/functional/live-embed.cy.ts
@@ -15,7 +15,7 @@ describe('Single Embed Code', () => {
           ></div>`,
         },
       })
-      cy.visit(`/live-embed.html`)
+      cy.visit(`/live-embed.html?bar=transitive`)
     })
 
     it('should display widget', () => {
@@ -26,6 +26,10 @@ describe('Single Embed Code', () => {
 
     it('should pass hidden fields as hash', () => {
       cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', '#foo=foo+value&email=foo%40bar.com')
+    })
+
+    it('should pass transitive search params', () => {
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', '&bar=transitive')
     })
   })
 })

--- a/packages/embed/src/utils/load-options-from-attributes.spec.ts
+++ b/packages/embed/src/utils/load-options-from-attributes.spec.ts
@@ -47,7 +47,11 @@ describe('load-options-from-attributes', () => {
         expect(transformAttributeValue('', 'boolean')).toBe(true)
       })
 
-      const falseValues = ['no', 'foo', null]
+      it('should transform null (attribute not found) to undefined', () => {
+        expect(transformAttributeValue(null, 'boolean')).toBe(undefined)
+      })
+
+      const falseValues = ['no', 'foo']
       falseValues.forEach((value) => {
         it(`should transform "${value}" to false`, () => {
           expect(transformAttributeValue(value, 'boolean')).toBe(false)
@@ -143,8 +147,8 @@ describe('load-options-from-attributes', () => {
       expect(transformAttributeValue('', 'integerOrBoolean')).toEqual(true)
     })
 
-    it('should return false if no value is provided', () => {
-      expect(transformAttributeValue(null, 'integerOrBoolean')).toEqual(false)
+    it('should return undefined if no value is provided', () => {
+      expect(transformAttributeValue(null, 'integerOrBoolean')).toEqual(undefined)
     })
   })
 
@@ -157,8 +161,8 @@ describe('load-options-from-attributes', () => {
       expect(transformAttributeValue('', 'integerOrBoolean')).toEqual(true)
     })
 
-    it('should return false if no value is provided', () => {
-      expect(transformAttributeValue(null, 'integerOrBoolean')).toEqual(false)
+    it('should return undefined if no value is provided', () => {
+      expect(transformAttributeValue(null, 'integerOrBoolean')).toEqual(undefined)
     })
   })
 
@@ -184,7 +188,6 @@ describe('load-options-from-attributes', () => {
         stringParam: 'foo',
         boolParam: true,
         boolParamYes: true,
-        nonExistantBoolParam: false,
       })
     })
   })

--- a/packages/embed/src/utils/load-options-from-attributes.ts
+++ b/packages/embed/src/utils/load-options-from-attributes.ts
@@ -25,7 +25,11 @@ const transformString = (value: string | null): string | undefined => {
   return value || undefined
 }
 
-const transformBoolean = (value: string | null): boolean => {
+const transformBoolean = (value: string | null): boolean | undefined => {
+  if (value === null) {
+    return undefined
+  }
+
   return value === '' || value === 'yes' || value === 'true'
 }
 


### PR DESCRIPTION
https://github.com/Typeform/embed/pull/621 introduced a bug in which, when loading a live embed code, boolean settings will always be set to `false` unless they are set to true in the element containing the `data-tf-live`.

This PR reverts that by enforcing that boolean settings should default to `undefined` if not found in the DOM element.