### PR TITLE
fix(NOJIRA-123): Set size in pixels by default

### DIFF
--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   visual:
     runs-on: ubuntu-latest
-    # skip for external PRs
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # skip for external PRs, run for push on main branch
+    if: ${{ !github.event.pull_request || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2

--- a/packages/embed/src/utils/set-element-size.spec.ts
+++ b/packages/embed/src/utils/set-element-size.spec.ts
@@ -1,4 +1,4 @@
-import { setElementSize } from './set-element-size'
+import { getValueWithUnits, setElementSize } from './set-element-size'
 
 describe('set-element-size', () => {
   describe('#setElementSize', () => {
@@ -18,7 +18,7 @@ describe('set-element-size', () => {
 
     it('should return an element with width and height', () => {
       const element = document.createElement('div')
-      expect(setElementSize(element, { width: 100, height: 100 })).toHaveStyle({
+      expect(setElementSize(element, { width: 100, height: '100' })).toHaveStyle({
         width: '100px',
         height: '100px',
       })
@@ -35,6 +35,20 @@ describe('set-element-size', () => {
       const sizedElement = setElementSize(element, { width: '100%', height: '50vh' })
       expect(sizedElement).toHaveStyle('width: 100%')
       expect(sizedElement).toHaveStyle('height: 50vh')
+    })
+  })
+
+  describe('#getValueWithUnits', () => {
+    it('should return size in pixels for number value', () => {
+      expect(getValueWithUnits(100)).toBe('100px')
+    })
+
+    it('should return size in pixels for string value containing only numbers', () => {
+      expect(getValueWithUnits('100')).toBe('100px')
+    })
+
+    it('should keep original units when provided in the value', () => {
+      expect(getValueWithUnits('100vh')).toBe('100vh')
     })
   })
 })

--- a/packages/embed/src/utils/set-element-size.ts
+++ b/packages/embed/src/utils/set-element-size.ts
@@ -4,7 +4,7 @@ interface ElementSize {
 }
 
 export const getValueWithUnits = (value: number | string): string => {
-  if (typeof value === 'string') {
+  if (typeof value === 'string' && !value.match(/^[0-9]+$/)) {
     return value
   } else {
     return `${value}px`


### PR DESCRIPTION
When value with no units (string with numbers only) is provided, set size in pixels by default.

Both examples below will assume value in pixels:
```javascript
window.tf.createWidget(formId, {
  height: "585",  // this PR fixes this case
});

window.tf.createWidget(formId, {
  height: 585,
});
```