### PR TITLE
chore(TU-2561): Trigger external update to developers

### DIFF
--- a/.github/workflows/trigger-external-update.yml
+++ b/.github/workflows/trigger-external-update.yml
@@ -20,5 +20,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.GH_TOKEN }}
-          repository: Typeform/dev-portal-content
+          repository: Typeform/developers
           event-type: update_embed_docs


### PR DESCRIPTION
Trigger external updates to `developers` instead of the archived `dev-portal-content`