### PR TITLE
fix(TU-7496): Require TS >=4.4.0

### DIFF
--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "clean": "rm -rf ./build ./build-aws ./types",
     "build": "yarn webpack",
-    "postbuild": "tsc -p tsconfig.json --emitDeclarationOnly --declaration --declarationDir types --skipLibCheck",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --declaration --declarationDir types --skipLibCheck",
+    "build:unsupported": "echo '\"Package '@typeform/embed' requires TS version >=4.4.0\".' > types/not-supported-ts-version.d.ts",
+    "postbuild": "yarn build:types && yarn build:unsupported",
     "dev": "yarn build --watch",
     "preview": "yarn concurrently 'CSS_URL=\"http://localhost:9022/css/\" yarn dev' 'yarn preview:serve'",
     "preview:serve": "yarn http-server -p 9022 -c-1 ./build",
@@ -59,5 +61,17 @@
   "files": [
     "build",
     "types"
-  ]
+  ],
+  "typesVersions": {
+    ">=4.4.0": {
+      "*": [
+        "*"
+      ]
+    },
+    "*": {
+      "*": [
+        "types/not-supported-ts-version.d.ts"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Require Typescript version 4.4.0 in `@typeform/embed` by raising a deliberate TS error when using the package in lower versions.

This is necessary to use modern features such as Template Literals as object keys (see this issue: https://github.com/Typeform/embed/issues/631)

Resolves #631