### PR TITLE
feat(TU-8207): Handle form redirects in embed SDK

### DIFF
--- a/packages/embed/src/utils/build-iframe-src.spec.ts
+++ b/packages/embed/src/utils/build-iframe-src.spec.ts
@@ -18,7 +18,8 @@ describe('build-iframe-src', () => {
             '&typeform-embed=embed-widget' +
             '&typeform-source=localhost' +
             '&typeform-medium=embed-sdk' +
-            '&typeform-medium-version=next'
+            '&typeform-medium-version=next' +
+            '&typeform-embed-handles-redirect=1'
         )
       })
     })
@@ -31,7 +32,8 @@ describe('build-iframe-src', () => {
           '&typeform-embed=embed-widget' +
           '&typeform-source=localhost' +
           '&typeform-medium=embed-sdk' +
-          '&typeform-medium-version=next'
+          '&typeform-medium-version=next' +
+          '&typeform-embed-handles-redirect=1'
         expect(buildIframeSrc({ formId, type: 'widget', embedId: 'embed-id', options: {} })).toBe(
           `${formId}${iframeSrcParams}`
         )
@@ -45,7 +47,8 @@ describe('build-iframe-src', () => {
           '&typeform-embed=embed-widget' +
           '&typeform-source=localhost' +
           '&typeform-medium=embed-sdk' +
-          '&typeform-medium-version=next'
+          '&typeform-medium-version=next' +
+          '&typeform-embed-handles-redirect=1'
         expect(
           buildIframeSrc({
             formId: 'formId',
@@ -64,7 +67,8 @@ describe('build-iframe-src', () => {
           '&typeform-embed=embed-widget' +
           '&typeform-source=localhost' +
           '&typeform-medium=embed-sdk' +
-          '&typeform-medium-version=next'
+          '&typeform-medium-version=next' +
+          '&typeform-embed-handles-redirect=1'
         expect(
           buildIframeSrc({ formId, type: 'widget', domain: 'foobar.example.net', embedId: 'embed-id', options: {} })
         ).toBe(`${formId}${iframeSrcParams}`)
@@ -127,6 +131,7 @@ describe('build-iframe-src', () => {
           '&embed-opacity=50' +
           '&disable-tracking=true' +
           '&__dangerous-disable-submissions=true' +
+          '&typeform-embed-handles-redirect=1' +
           '&typeform-embed-auto-resize=true' +
           '&typeform-embed-handle-ending-button-click=true' +
           '&utm_foo=utm+foo+value&foobar=foobar%26value' +
@@ -151,7 +156,8 @@ describe('build-iframe-src', () => {
           '&typeform-medium=unit-test-medium' +
           '&typeform-medium-version=unit-test-version' +
           '&disable-tracking=true' +
-          '&__dangerous-disable-submissions=true'
+          '&__dangerous-disable-submissions=true' +
+          '&typeform-embed-handles-redirect=1'
       )
     })
 

--- a/packages/embed/src/utils/build-iframe-src.ts
+++ b/packages/embed/src/utils/build-iframe-src.ts
@@ -70,6 +70,7 @@ const mapOptionsToQueryParams = (
     'force-touch': forceTouch ? 'true' : undefined,
     'add-placeholder-ws': type === 'widget' && displayAsFullScreenModal ? 'true' : undefined,
     'typeform-embed-redirect-target': redirectTarget,
+    'typeform-embed-handles-redirect': 1,
     'typeform-embed-auto-resize': autoResize ? 'true' : undefined,
     'typeform-embed-disable-scroll': disableScroll ? 'true' : undefined,
     'typeform-embed-handle-ending-button-click': !!onEndingButtonClick ? 'true' : undefined,

--- a/packages/embed/src/utils/create-iframe/create-iframe.ts
+++ b/packages/embed/src/utils/create-iframe/create-iframe.ts
@@ -11,6 +11,7 @@ import {
   getFormThemeHandler,
   getThankYouScreenButtonClickHandler,
   getFormStartedHandler,
+  getRedirectHandler,
 } from './get-form-event-handler'
 import { triggerIframeRedraw } from './trigger-iframe-redraw'
 import { dispatchCustomKeyEventFromIframe } from './setup-custom-keyboard-close'
@@ -65,6 +66,7 @@ export const createIframe = (type: EmbedType, { formId, domain, options }: Creat
   window.addEventListener('message', getFormSubmitHandler(embedId, onSubmit))
   window.addEventListener('message', getFormThemeHandler(embedId, onTheme))
   window.addEventListener('message', getThankYouScreenButtonClickHandler(embedId, onEndingButtonClick))
+  window.addEventListener('message', getRedirectHandler(embedId, iframe))
 
   if (type !== 'widget') {
     window.addEventListener('message', dispatchCustomKeyEventFromIframe)

--- a/packages/embed/src/utils/create-iframe/get-form-event-handler.ts
+++ b/packages/embed/src/utils/create-iframe/get-form-event-handler.ts
@@ -1,5 +1,7 @@
+import { handleFormRedirect } from './handle-form-redirect'
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type callbackFn = (ev?: any) => void
+type callbackFn = (data?: any) => void
 
 export const getFormReadyHandler = (embedId: string, callback?: callbackFn) => {
   return getFormEventHandler('form-ready', embedId, callback)
@@ -33,17 +35,31 @@ export const getThankYouScreenButtonClickHandler = (embedId: string, callback?: 
   return getFormEventHandler('thank-you-screen-button-click', embedId, callback)
 }
 
-function getFormEventHandler(eventType: string, expectedEmbedId: string, callback?: callbackFn) {
+export const getRedirectHandler = (embedId: string, iframe: HTMLIFrameElement) => {
+  return getFormEventHandler(
+    ['redirect-after-submit', 'thank-you-screen-redirect'],
+    embedId,
+    handleFormRedirect(iframe)
+  )
+}
+
+const isValidEventType = (expectedType: string | string[], type: string): boolean => {
+  if (Array.isArray(expectedType)) {
+    return expectedType.includes(type)
+  }
+  return expectedType === type
+}
+
+function getFormEventHandler(eventType: string | string[], expectedEmbedId: string, callback?: callbackFn) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (event: any) => {
     const { type, embedId, ...data } = event.data
-    if (type !== eventType) {
+    if (!isValidEventType(eventType, type)) {
       return
     }
     if (embedId !== expectedEmbedId) {
       return
     }
-
     callback?.(data)
   }
 }

--- a/packages/embed/src/utils/create-iframe/handle-form-redirect.spec.ts
+++ b/packages/embed/src/utils/create-iframe/handle-form-redirect.spec.ts
@@ -1,0 +1,80 @@
+import { handleFormRedirect } from './handle-form-redirect'
+
+describe('#handleFormRedirect', () => {
+  const iframe = document.createElement('iframe') as HTMLIFrameElement
+  const url = 'http://my/redirect/url'
+  const windowOpenSpy = jest.spyOn(window, 'open')
+  const consoleErrorSpy = jest.spyOn(console, 'error')
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: 'http://localhost',
+      },
+      writable: true,
+    })
+    windowOpenSpy.mockClear()
+    consoleErrorSpy.mockClear()
+  })
+
+  describe('with no target specified', () => {
+    it('should redirect in current window by default', () => {
+      handleFormRedirect(iframe)({ url })
+      expect(window.location.href).toBe(url)
+    })
+  })
+
+  describe('with target "_parent"', () => {
+    it('should redirect in current window with target "_parent"', () => {
+      handleFormRedirect(iframe)({ url, target: '_parent' })
+      expect(window.location.href).toBe(url)
+    })
+  })
+
+  describe('with target "_self"', () => {
+    it('should redirect in the iframe ', () => {
+      handleFormRedirect(iframe)({ url, target: '_self' })
+      expect(iframe.src).toBe(url)
+    })
+
+    describe('when URL contains a hash fragment', () => {
+      it('should add Date.now() to the URL when it is the same form URL', () => {
+        const iframe = document.createElement('iframe') as HTMLIFrameElement
+        iframe.src = 'http://my/form'
+        handleFormRedirect(iframe)({ url: 'http://my/form#foo', target: '_self' })
+        expect(iframe.src).toMatch(/http:\/\/my\/form\?tf-embed-ts=[0-9]+#foo/)
+      })
+
+      it('should not add Date.now() to the URL is different', () => {
+        const iframe = document.createElement('iframe') as HTMLIFrameElement
+        iframe.src = 'http://my/form'
+        handleFormRedirect(iframe)({ url: 'http://different/form#foo', target: '_self' })
+        expect(iframe.src).toBe('http://different/form#foo')
+      })
+    })
+  })
+
+  describe('with target "_blank"', () => {
+    it('should redirect in new tab', () => {
+      handleFormRedirect(iframe)({ url, target: '_blank' })
+      expect(window.open).toHaveBeenCalledTimes(1)
+      expect(window.open).toHaveBeenCalledWith(url, '_blank')
+    })
+  })
+
+  describe('with target "_top"', () => {
+    it('should redirect in top window ', () => {
+      handleFormRedirect(iframe)({ url, target: '_parent' })
+      expect(window.location.href).toBe(url)
+    })
+  })
+
+  describe('with no URL', () => {
+    it('should not redirect and log error', () => {
+      handleFormRedirect(iframe)({} as unknown as { url: string })
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(1)
+      expect(window.location.href).toBe('http://localhost')
+    })
+  })
+})

--- a/packages/embed/src/utils/create-iframe/handle-form-redirect.ts
+++ b/packages/embed/src/utils/create-iframe/handle-form-redirect.ts
@@ -1,0 +1,42 @@
+const updateUrlWithHash = (currentUrl: string, newUrl: string): string => {
+  if (!newUrl.includes('#')) {
+    return newUrl
+  }
+  if (!newUrl.startsWith(`${currentUrl}#`)) {
+    return newUrl
+  }
+  if (newUrl.includes('?')) {
+    return newUrl.replace('#', `&tf-embed-ts=${Date.now()}#`)
+  }
+  return newUrl.replace('#', `?tf-embed-ts=${Date.now()}#`)
+}
+export const handleFormRedirect =
+  (iframe: HTMLIFrameElement) =>
+  ({ url, target = '_parent' }: { url: string; target?: string }) => {
+    if (!url) {
+      // eslint-disable-next-line no-console
+      console.error('Redirect failed, no URL provided')
+      return
+    }
+
+    switch (target) {
+      case '_self':
+        iframe.src = updateUrlWithHash(iframe.src, url)
+        break
+      case '_blank':
+        window.open(url, '_blank')
+        break
+      case '_top':
+        const anchor = document.createElement('a')
+        anchor.href = url
+        anchor.target = '_top'
+        document.body.appendChild(anchor)
+        anchor.click()
+        document.body.removeChild(anchor)
+        break
+      default:
+      case '_parent':
+        window.location.href = url
+        break
+    }
+  }


### PR DESCRIPTION
For embedded forms if we let the embed SDK handle redirects it will avoid privacy issues in Safari (access to query params, opening new tabs).
