### PR TITLE
fix(TU-15898): Disable auto-resize for widgets in modal on mobile

### DIFF
--- a/packages/embed/src/factories/create-widget/create-widget.ts
+++ b/packages/embed/src/factories/create-widget/create-widget.ts
@@ -44,6 +44,7 @@ export const createWidget = (formId: string, options: WidgetOptions): Widget => 
   if (!widgetOptions.inlineOnMobile && (widgetOptions.forceTouch || isFullscreen())) {
     widgetOptions.displayAsFullScreenModal = true
     widgetOptions.forceTouch = true
+    widgetOptions.autoResize = false
   }
 
   const { embedId, iframe, refresh, focus } = createIframe('widget', { formId, domain, options: widgetOptions })


### PR DESCRIPTION
When widget is embedded on mobile, it is displayed in fullscreen modal. The auto-resize setting does not make sense in that case and should be disabled.