### PR TITLE
fix(NOJIRA-123): Prevent loading live embed multiple times

### DIFF
--- a/packages/demo-html/public/live-embed.html
+++ b/packages/demo-html/public/live-embed.html
@@ -27,7 +27,7 @@
   </head>
   <body>
     <div class="element">I have z-index 10k</div>
-    <div id="wrapper" data-tf-live="embed-id" data-tf-hidden="email=foo@bar.com"></div>
+    <div id="wrapper" data-tf-live="01J5X1H8WM5CSXVDN89WXNX5EB" data-tf-hidden="email=foo@bar.com"></div>
     <script src="./lib/embed.js"></script>
   </body>
 </html>

--- a/packages/embed/e2e/spec/functional/live-embed.cy.ts
+++ b/packages/embed/e2e/spec/functional/live-embed.cy.ts
@@ -1,7 +1,7 @@
 describe('Single Embed Code', () => {
   describe(`Should load`, () => {
     before(() => {
-      cy.intercept('https://api.typeform.com/single-embed/embed-id', {
+      cy.intercept('https://api.typeform.com/single-embed/01J5X1H8WM5CSXVDN89WXNX5EB', {
         statusCode: 200,
         body: {
           html: `<div

--- a/packages/embed/src/initializers/initialize-live-embeds.ts
+++ b/packages/embed/src/initializers/initialize-live-embeds.ts
@@ -12,17 +12,19 @@ export const initializeLiveEmbeds = ({
 
   for (let index = 0; index < embedTypeElements.length; index += 1) {
     const element = embedTypeElements.item(index)
-    if (forceReload || element.dataset.tfLoaded !== 'true') {
+    const canBeLoaded = element.dataset.tfLoading !== 'true' && element.dataset.tfLoaded !== 'true'
+    if (canBeLoaded || forceReload) {
       const embedId = element.getAttribute(LIVE_EMBED_ATTRIBUTE)
       if (!embedId) {
         throw new Error(`Invalid ${LIVE_EMBED_ATTRIBUTE}=${embedId} for embed #${index}`)
       }
+      element.dataset.tfLoading = 'true'
 
       fetchLiveEmbed(embedId).then(({ html }) => {
         element.innerHTML = html
-        element.dataset.tfLoaded = 'true'
-
         onLiveEmbedLoad(element)
+        delete element.dataset.tfLoading
+        element.dataset.tfLoaded = 'true'
       })
     }
   }


### PR DESCRIPTION
When the SDK is included multiple times, live embeds get loaded multiple times because they are loaded async. Customers may end up with multiple `embed.js` scripts in their website when they copy-paste multiple embed snippets into one page.

The issue is most visible when the embedded form opens automatically, eg. on load, [as reported in this community thread](https://community.typeform.com/share-your-typeform-6/form-popping-up-twice-14923).