### PR TITLE
fix(TU-21474): Remove overflow on widget close

### DIFF
--- a/packages/demo-nextjs/next-env.d.ts
+++ b/packages/demo-nextjs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/packages/embed/src/factories/create-widget/create-widget.ts
+++ b/packages/embed/src/factories/create-widget/create-widget.ts
@@ -40,6 +40,7 @@ export const createWidget = (formId: string, options: WidgetOptions): Widget => 
 
   const { domain, ...widgetOptions } = options
   widgetOptions.inlineOnMobile = options.inlineOnMobile || options.fullScreen
+  const scrollInitialState = document.body.style.overflow
 
   if (!widgetOptions.inlineOnMobile && (widgetOptions.forceTouch || isFullscreen())) {
     widgetOptions.displayAsFullScreenModal = true
@@ -116,6 +117,10 @@ export const createWidget = (formId: string, options: WidgetOptions): Widget => 
       options.onClose?.()
       container.classList.remove('tf-v1-widget-fullscreen')
       container.style.backgroundColor = ''
+
+      if (widgetOptions.fullScreen) {
+        document.body.style.overflow = scrollInitialState
+      }
 
       if (options.keepSession) {
         const overlay = document.createElement('div')


### PR DESCRIPTION
Resolves #673

This behaviour is already existing for the Popup and Slider embeds so bringing this over to the Widget when the fullScreen option is enabled.