### PR TITLE
build(PLT-816): Update workflows to use temporary credentials

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,6 +85,9 @@ jobs:
     runs-on: ubuntu-latest
     # skip for external PRs
     if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -121,11 +124,19 @@ jobs:
       - run: yarn add -W @typeform/jarvis
       - run: git checkout HEAD -- package.json # do not save jarvis dependency to package.json because it is private (the file is committed by semantic-release to bump version)
 
+      # authenticate to AWS
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: 'us-east-1'
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
+          role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
+          role-duration-seconds: 900
+          unset-current-credentials: true
+
       - run: yarn release:preview
         env:
           AWS_ASSETS_BUCKET: 'typeform-public-assets/embed'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           JARVIS_NOTIFY_PREVIEW_TEMPLATE: ${{ secrets.JARVIS_NOTIFY_PREVIEW_TEMPLATE }}
           PUBLIC_CDN_URL: 'https://embed.typeform.com'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           aws-region: 'us-east-1'
           mask-aws-account-id: true
-          role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
           role-duration-seconds: 900
           unset-current-credentials: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -50,12 +53,20 @@ jobs:
       - run: yarn add -W @typeform/jarvis
       - run: git checkout HEAD -- package.json # do not save jarvis dependency to package.json because it is private (the file is committed by semantic-release to bump version)
 
+      # authenticate to AWS
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: 'us-east-1'
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
+          role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
+          role-duration-seconds: 900
+          unset-current-credentials: true
+
       - run: yarn release
         env:
           AWS_ASSETS_BUCKET: 'typeform-public-assets/embed'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_CLOUDFRONT_DIST: 'E3IUO95IYL1RI3'
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLIC_CDN_URL: 'https://embed.typeform.com'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           aws-region: 'us-east-1'
           mask-aws-account-id: true
-          role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE }}
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: ${{ github.run_id }}-${{ github.run_attempt }}
           role-duration-seconds: 900
           unset-current-credentials: true


### PR DESCRIPTION
This PR updates the repository workflows to use temporary credentials generated by this action: https://github.com/aws-actions/configure-aws-credentials.

Before the workflow will run successfully, we will need to add the following Github Secret: `DEPLOYMENT_ROLE_ARN` with the value set to the appropriate role.