### PR TITLE
fix(TU-18127): Replace __dangerous-disable-submissions with enable-sandbox=true

### DIFF
--- a/packages/embed/src/utils/build-iframe-src.spec.ts
+++ b/packages/embed/src/utils/build-iframe-src.spec.ts
@@ -195,7 +195,7 @@ describe('build-iframe-src', () => {
           '&embed-hide-headers=true' +
           '&embed-opacity=50' +
           '&disable-tracking=true' +
-          '&__dangerous-disable-submissions=true' +
+          '&enable-sandbox=true' +
           '&typeform-embed-handles-redirect=1' +
           '&typeform-embed-auto-resize=true' +
           '&typeform-embed-handle-ending-button-click=true' +
@@ -208,7 +208,7 @@ describe('build-iframe-src', () => {
       )
     })
 
-    it('should disable tracking and submission on sandbox mode', () => {
+    it('should disable tracking and enable sandbox mode when on sandbox mode', () => {
       const options = {
         source: 'unit-test-source',
         medium: 'unit-test-medium',
@@ -224,7 +224,7 @@ describe('build-iframe-src', () => {
           '&typeform-medium=unit-test-medium' +
           '&typeform-medium-version=unit-test-version' +
           '&disable-tracking=true' +
-          '&__dangerous-disable-submissions=true' +
+          '&enable-sandbox=true' +
           '&typeform-embed-handles-redirect=1'
       )
     })

--- a/packages/embed/src/utils/build-iframe-src.ts
+++ b/packages/embed/src/utils/build-iframe-src.ts
@@ -66,7 +66,7 @@ const mapOptionsToQueryParams = (
     'embed-hide-headers': hideHeaders ? 'true' : undefined,
     'embed-opacity': opacity,
     'disable-tracking': disableTracking || enableSandbox ? 'true' : undefined,
-    '__dangerous-disable-submissions': enableSandbox ? 'true' : undefined,
+    'enable-sandbox': enableSandbox ? 'true' : undefined,
     'share-ga-instance': shareGaInstance ? 'true' : undefined,
     'force-touch': forceTouch ? 'true' : undefined,
     'add-placeholder-ws': type === 'widget' && displayAsFullScreenModal ? 'true' : undefined,


### PR DESCRIPTION
## Summary
https://typeform.atlassian.net/browse/TU-18127

Separate sandbox mode behaviour from submission-disabled mode by introducing a distinct `enable-sandbox` query parameter.

 ## Problem
Previously, `enableSandbox: true` in the embed SDK would pass `__dangerous-disable-submissions=true` to the `renderer`, causing sandbox mode and submission-disabled mode to be treated identically. This prevents redirects from working in sandboxed embeds.

## Solution

Pass `enable-sandbox=true` instead of `__dangerous-disable-submissions=true` when `enableSandbox` is set, allowing the renderer to distinguish between the two flows.