### PR TITLE
chore: add tmp new RX tests

### DIFF
--- a/packages/demo-html/public/widget-newui-html.html
+++ b/packages/demo-html/public/widget-newui-html.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Static HTML Demo</title>
+    <style>
+      #wrapper {
+        width: 100%;
+        max-width: 600px;
+        height: 400px;
+        margin: 0 auto;
+      }
+      .element {
+        position: fixed;
+        bottom: 0;
+        right: 0;
+        background: red;
+        color: white;
+        padding: 10px;
+        width: 200px;
+        height: 60px;
+        line-height: 40px;
+        z-index: 10000;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="element">I have z-index 10k</div>
+    <div
+      id="wrapper"
+      data-tf-widget="Afg8crxm"
+      data-tf-medium="demo-test"
+      data-tf-transitive-search-params="foo,bar"
+      data-tf-hidden="foo=foo value"
+      data-tf-tracking="utm_source=facebook"
+      data-tf-iframe-props="title=Foo Bar"
+    ></div>
+    <script src="./lib/embed.js"></script>
+  </body>
+</html>

--- a/packages/demo-html/public/widget-newui-js.html
+++ b/packages/demo-html/public/widget-newui-js.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Static HTML Demo</title>
+    <style>
+      #wrapper {
+        width: 100%;
+        max-width: 600px;
+        height: 400px;
+        margin: 0 auto;
+      }
+      .element {
+        position: fixed;
+        bottom: 0;
+        right: 0;
+        background: red;
+        color: white;
+        padding: 10px;
+        width: 200px;
+        height: 60px;
+        line-height: 40px;
+        z-index: 10000;
+      }
+    </style>
+    <link rel="stylesheet" href="./lib/css/widget.css" />
+  </head>
+  <body>
+    <div class="element">I have z-index 10k</div>
+    <div id="wrapper"></div>
+    <script src="./lib/embed.js"></script>
+    <script>
+      window.tf.createWidget('Afg8crxm', {
+        container: document.getElementById('wrapper'),
+        transitiveSearchParams: ['foo', 'bar'],
+        medium: 'demo-test',
+        hidden: { foo: 'foo value' },
+        iframeProps: { title: 'Foo Bar' },
+      })
+    </script>
+  </body>
+</html>

--- a/packages/embed/e2e/spec/functional/widget-newui.cy.ts
+++ b/packages/embed/e2e/spec/functional/widget-newui.cy.ts
@@ -1,0 +1,68 @@
+import { openOnMobile } from '../../cypress-utils'
+
+describe('Widget', () => {
+  testWidget('/widget-newui-html.html', 'html')
+  testWidget('/widget-newui-js.html', 'javascript')
+  testWidget('/', 'server-side rendering')
+})
+
+describe('Widget - Mobile', () => {
+  testMobile('/widget-newui-html.html', 'html')
+  testMobile('/widget-newui-js.html', 'javascript')
+})
+
+function testWidget(path: string, title: string) {
+  describe(`Widget - ${title}`, () => {
+    before(() => {
+      cy.visit(`${path}?foo=foo&bar=bar&baz=baz`)
+    })
+
+    it('should display widget', () => {
+      cy.get('.tf-v1-widget iframe').should('be.visible')
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', 'form.typeform.com/to/')
+    })
+
+    it('should pass options as query param', () => {
+      cy.get('.tf-v1-widget iframe')
+        .invoke('attr', 'src')
+        .should('contain', 'typeform-embed=embed-widget&typeform-source=localhost&typeform-medium=demo-test')
+    })
+
+    it('should pass hidden fields as hash', () => {
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', '#foo=foo+value')
+    })
+
+    it('should pass params from options to the iframe', () => {
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('contain', 'bar=bar')
+    })
+
+    it('should not pass params not in the list to the iframe', () => {
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'src').should('not.contain', 'baz=baz')
+    })
+
+    it('should pass additional iframe props', () => {
+      cy.get('.tf-v1-widget iframe').invoke('attr', 'title').should('equal', 'Foo Bar')
+    })
+  })
+}
+
+function testMobile(path: string, title: string) {
+  describe(`Widget - ${title}`, () => {
+    before(() => {
+      openOnMobile(`${path}?foo=foo&bar=bar&baz=baz`)
+    })
+
+    it('should reset the form when closing it', () => {
+      cy.get('iframe').then(($iframe) => {
+        const $body = $iframe.contents().find('body')
+        cy.wrap($body).find('[data-qa="ok-button"]').click()
+        cy.get('.tf-v1-widget-close').click()
+      })
+      cy.wait(1000)
+      cy.get('iframe').then(($iframe) => {
+        const $body = $iframe.contents().find('body')
+        cy.wrap($body).find('[data-qa="ok-button"]').should('exist')
+      })
+    })
+  })
+}


### PR DESCRIPTION
All the embed e2e and visual tests are currently excluded from the new renderer RX. However, the RX has been rolled out to 99% of users and we don't want to be completely in the dark. Because of that I'm suggesting we add just one duplicate test which tests a form that's been specifically added to the feature flag.