### PR TITLE
feat(TU-33149): Stop use of npm config commands

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -19,9 +19,9 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .js,.ts,.jsx,.tsx --max-warnings=0",
-    "release": "npm config set @typeform:registry https://registry.npmjs.org/ && yarn semantic-release",
+    "release": "yarn semantic-release",
     "post-release": "yarn release:github",
-    "release:github": "npm config set @typeform:registry https://npm.pkg.github.com/ && npm publish"
+    "release:github": "npm publish --registry https://npm.pkg.github.com/"
   },
   "dependencies": {
     "@typeform/embed": "5.5.1",
@@ -34,6 +34,9 @@
     "build",
     "types"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:Typeform/embed.git",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -49,9 +49,9 @@
     "cy:visual": "yarn cypress run --spec e2e/spec/visual/**/* --env testType=visual",
     "test:functional": "start-server-and-test demo 9090 cy:functional",
     "test:visual": "start-server-and-test demo 9090 cy:visual",
-    "release-vanilla": "npm config set @typeform:registry https://registry.npmjs.org/ && yarn semantic-release",
+    "release-vanilla": "yarn semantic-release",
     "post-release": "yarn release:github && yarn release:aws",
-    "release:github": "npm config set @typeform:registry https://npm.pkg.github.com/ && npm publish",
+    "release:github": "npm publish --registry https://npm.pkg.github.com/",
     "release:aws": "yarn release:aws:prepare && yarn release:aws:deploy",
     "release:aws:prepare": "sh ./scripts/prepare-release.sh",
     "release:aws:deploy": "DEBUG=jarvis yarn run jarvis deploy --path ./build-aws --version next",
@@ -62,6 +62,9 @@
     "build",
     "types"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "typesVersions": {
     ">=4.4.0": {
       "*": [


### PR DESCRIPTION
The OIDC migration upgraded semantic-release packages to versions that use `npm 10.x`. In `npm 10.x`, `npm config set` commands do not appear to work from within workspace package directories (monorepos with "workspaces"), causing `ENOWORKSPACES` errors. 

Changed the configuration to avoid using `npm config ...` commands.
  - `publishConfig` explicitly declares the default registry for semantic-release
  - `--registry flag` in `release:github` explicitly overrides to publish to GitHub Packages
  - No npm config commands = no workspace errors (hopefully 🤞 )