### PR TITLE
feat(TU-33149): Use an explicit --registry flag for jarvis install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,7 @@ jobs:
       - run: npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - run: npm config set @typeform:registry https://npm.pkg.github.com/ # install jarvis from github
-      - run: yarn add -W @typeform/jarvis
-      - run: git checkout HEAD -- package.json # do not save jarvis dependency to package.json because it is private (the file is committed by semantic-release to bump version)
+      - run: npm install @typeform/jarvis --registry=https://npm.pkg.github.com/ --no-save
 
       # authenticate to AWS
       - uses: aws-actions/configure-aws-credentials@v4
@@ -68,7 +66,7 @@ jobs:
           AWS_CLOUDFRONT_DIST: 'E3IUO95IYL1RI3'
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Hybrid approach: NPM_TOKEN used for verification, OIDC used for actual publishing
+          # Hybrid approach: NPM_TOKEN for verification, OIDC for publishing
           PUBLIC_CDN_URL: 'https://embed.typeform.com'
           SEGMENT_WRITE_KEY: ${{ secrets.DEPLOYMENT_SEGMENT_WRITE_KEY }}
 


### PR DESCRIPTION
The workflow was setting a global registry override for @typeform scoped packages:
`npm config set @typeform:registry https://npm.pkg.github.com/`

Idea is that this stayed in effect during the release, causing `semantic-release` to check authentication against GitHub Packages instead of npmjs.org, resulting in the error.

https://typeform.slack.com/archives/C01HXMZGU9E/p1765375968262809?thread_ts=1765366708.689729&cid=C01HXMZGU9E
