### PR TITLE
feat(TU-33149): Revert to previous jarvis install method but cleanup the registry override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,10 @@ jobs:
       - run: npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - run: npm install @typeform/jarvis --registry=https://npm.pkg.github.com/ --no-save --legacy-peer-deps
+      - run: npm config set @typeform:registry https://npm.pkg.github.com/
+      - run: yarn add -W @typeform/jarvis
+      - run: git checkout HEAD -- package.json # do not save jarvis dependency to package.json because it is private (the file is committed by semantic-release to bump version)
+      - run: npm config delete @typeform:registry
 
       # authenticate to AWS
       - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Reverting to the previous method of installing `jarvis` given I know that works. The alternative, shorter approach is causing more problems. 

Difference to the original implementation is that we now clean-up the registry override which should hopefully solve the semantic-release issues (the original problem that the shorter approach was attempting to resolve).