### PR TITLE
feat(TU-33149): Change the way we invoke semantic-release-monorepo

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,9 +2,6 @@
   "branches": [
     "main"
   ],
-  "extends": [
-    "semantic-release-monorepo"
-  ],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "releaseRules": [

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -19,7 +19,7 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .js,.ts,.jsx,.tsx --max-warnings=0",
-    "release": "yarn semantic-release",
+    "release": "yarn semantic-release -e semantic-release-monorepo",
     "post-release": "yarn release:github",
     "release:github": "npm publish --registry https://npm.pkg.github.com/"
   },

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -49,7 +49,7 @@
     "cy:visual": "yarn cypress run --spec e2e/spec/visual/**/* --env testType=visual",
     "test:functional": "start-server-and-test demo 9090 cy:functional",
     "test:visual": "start-server-and-test demo 9090 cy:visual",
-    "release-vanilla": "yarn semantic-release",
+    "release-vanilla": "yarn semantic-release -e semantic-release-monorepo",
     "post-release": "yarn release:github && yarn release:aws",
     "release:github": "npm publish --registry https://npm.pkg.github.com/",
     "release:aws": "yarn release:aws:prepare && yarn release:aws:deploy",


### PR DESCRIPTION
The `semantic-release-monorepo` plugin is not loading leading to the release flow not picking up the latest git tags and attempting to analyse ALL commits.

Theory is that when you define plugins in `.releaserc`, it overrides any plugins from extended configs.
Hoping that the -e flag works differently - allowing `semantic-release-monorepo` to wrap the plugins at runtime.