### PR TITLE
feat(TU-33149): Attempting to avoid polluting global .npmrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,15 +43,24 @@ jobs:
       - run: yarn build
         env:
           NODE_ENV: 'production'
-      # Configure registry for GitHub Packages
+      # Configure registry for GitHub Packages using local .npmrc to avoid npm global config corruption
       - run: rm ./.npmrc
-      - run: npm config set '//npm.pkg.github.com/:_authToken' $GH_TOKEN
+      - run: |
+          cat > .npmrc << 'EOF'
+          //npm.pkg.github.com/:_authToken=${GH_TOKEN}
+          @typeform:registry=https://npm.pkg.github.com/
+          EOF
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - run: npm config set @typeform:registry https://npm.pkg.github.com/
       - run: yarn add -W @typeform/jarvis
       - run: git checkout HEAD -- package.json # do not save jarvis dependency to package.json because it is private (the file is committed by semantic-release to bump version)
-      - run: npm config delete @typeform:registry
+      # Create clean .npmrc with just auth token
+      - run: |
+          cat > .npmrc << 'EOF'
+          //npm.pkg.github.com/:_authToken=${GH_TOKEN}
+          EOF
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       # authenticate to AWS
       - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Looks like `semantic-release-monorepo` is now being used correctly. 
Now facing a new error:
```
[1:17:08 PM] [semantic-release] [@semantic-release/npm] › ℹ  Write version 5.6.0 to package.json in /home/runner/work/embed/embed/packages/embed
npm warn Unknown env config "version-commit-hooks". This will stop working in the next major version of npm.
npm warn Unknown env config "version-tag-prefix". This will stop working in the next major version of npm.
npm warn Unknown env config "yarn-path". This will stop working in the next major version of npm.
npm warn Unknown env config "ignore-path". This will stop working in the next major version of npm.
npm warn Unknown env config "version-git-message". This will stop working in the next major version of npm.
npm warn Unknown env config "argv". This will stop working in the next major version of npm.
npm warn Unknown env config "version-git-tag". This will stop working in the next major version of npm.
npm error LRU is not a constructor
```
This PR attempts to avoid polluting global `.npmrc` file by creating a local instance instead. With the idea that it is said pollution leading to the helpful error of `LRU is not a constructor`...