### PR TITLE
feat(TU-33149): Update branches config .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,6 @@
 {
   "branches": [
-    "main"
+    {"name": "main", "channel": false}
   ],
   "plugins": [
     ["@semantic-release/commit-analyzer", {


### PR DESCRIPTION
In the last `release`, the NPM packages were tagged with `main` and the GH releases were tagged with `Pre-release`.
From what I have read in documentation, you can set `channel: false` to force:
  - npm: publish to `latest` dist-tag
  - GitHub: create a normal release (not pre-release)