### PR TITLE
fix(PLT-3359): harden yarn configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 registries:
   npm-github:
     type: npm-registry
@@ -10,7 +9,6 @@ registries:
     url: https://github.com
     username: x-access-token
     password: '${{ secrets.GH_TOKEN }}'
-
 updates:
   - package-ecosystem: npm
     schedule:
@@ -27,7 +25,14 @@ updates:
     registries:
       - npm-github
       - git-github
-
+    cooldown:
+      default-days: 7
+      exclude:
+        - '@typeform/*'
+    ignore:
+      - dependency-name: semantic-release
+        versions:
+          - '>=25.0.0'
   - package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -76,6 +76,9 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
+      - name: Install Cypress binary
+        run: yarn cypress install
+
       - run: yarn build
       - run: yarn test:functional
 

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -33,6 +33,9 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
+      - name: Install Cypress binary
+        run: yarn cypress install
+
       - run: yarn build
 
       - run: yarn test:visual

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+ignore-scripts true
+save-exact true


### PR DESCRIPTION
## Harden yarn configuration
This PR hardens yarn configuration against supply chain attacks.

### Changes
- **`.yarnrc`**: Added `ignore-scripts true` and `save-exact true`.
- **Dependabot**: Added a 7-day `cooldown` for third-party npm updates (excluding `@typeform/*`).
- **Compatibility**: Maintained `semantic-release` version locks for Node 22 compatibility.

---
_Automated by Application Security · supply-chain-hardening_

[_Created by Sourcegraph batch change `david.salvador/harden-yarn-config`._](https://typeform.sourcegraphcloud.com/users/david.salvador/batch-changes/harden-yarn-config)